### PR TITLE
Fix zero hysteresis handling

### DIFF
--- a/.homeycompose/drivers/settings/hysteresis.json
+++ b/.homeycompose/drivers/settings/hysteresis.json
@@ -6,6 +6,6 @@
   },
   "value": 0.5,
   "hint": {
-    "en": "With a hysteresis value of 0.5, the temperature will vary between 0.5 below the target temperature and 0.5 above the target temperature."
+    "en": "With a hysteresis value of 0.5, the temperature will vary between 0.5 below and 0.5 above the target temperature. A value of 0 switches whenever the temperature crosses the target and may cause rapid switching."
   }
 }

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Select temperature sensors from the sub zones of the virtual thermostat, just on
 
 #### General settings
 
-- Hysteresis: to avoid that the thermostat will turn on and off too often, the hysteresis value must be greater than zero. Example: with a value of 0.5, and a target temperature of 20.0 °C, the thermostat will switch on if below 20.0 - 0.5, and off if above 20.0 + 0.5.
+- Hysteresis: use a positive value to avoid switching the thermostat on and off too often. Example: with a value of 0.5 and a target temperature of 20.0 °C, the thermostat switches on below 19.5 °C and off above 20.5 °C. A value of 0 is supported and switches whenever the temperature crosses the target, but it can cause rapid switching and may reduce relay or heater lifetime. At exactly the target, the current state is retained.
 - Invert switch: check this and the thermostat will switch on if above the target, and switch off if below the target.
 - On / off enabled: uncheck this to disable the thermostat On / Off - switch.
 

--- a/app.json
+++ b/app.json
@@ -608,7 +608,7 @@
               "id": "hysteresis",
               "value": 1,
               "hint": {
-                "en": "With a hysteresis value of 1, the device will vary between 1 below the target humidity and 1 above the target humidity."
+                "en": "With a hysteresis value of 1, the humidity will vary between 1 below and 1 above the target. A value of 0 switches whenever the humidity crosses the target and may cause rapid switching."
               },
               "type": "number",
               "label": {
@@ -1243,7 +1243,7 @@
               },
               "value": 0.5,
               "hint": {
-                "en": "With a hysteresis value of 0.5, the temperature will vary between 0.5 below the target temperature and 0.5 above the target temperature."
+                "en": "With a hysteresis value of 0.5, the temperature will vary between 0.5 below and 0.5 above the target temperature. A value of 0 switches whenever the temperature crosses the target and may cause rapid switching."
               }
             },
             {

--- a/drivers/VHumidity/driver.settings.compose.json
+++ b/drivers/VHumidity/driver.settings.compose.json
@@ -26,7 +26,7 @@
         "id": "hysteresis",
         "value": 1,
         "hint": {
-          "en": "With a hysteresis value of 1, the device will vary between 1 below the target humidity and 1 above the target humidity."
+          "en": "With a hysteresis value of 1, the humidity will vary between 1 below and 1 above the target. A value of 0 switches whenever the humidity crosses the target and may cause rapid switching."
         }
       },
       {

--- a/lib/VHumidityDeviceCalculator.ts
+++ b/lib/VHumidityDeviceCalculator.ts
@@ -172,7 +172,7 @@ export class VHumidityDeviceCalculator extends DeviceCalculator {
         if (!mainOnoff) {
             onoff = currentVtOnoff === true ? false : undefined;
         } else {
-            const hysteresis = deviceSettings.hysteresis || 1;
+            const hysteresis = deviceSettings.hysteresis ?? 1;
             const invert = deviceSettings.invert;
             if (humidity > targetHumidity + hysteresis) {
                 onoff = invert !== true;

--- a/lib/VThermoDeviceCalculator.ts
+++ b/lib/VThermoDeviceCalculator.ts
@@ -243,9 +243,12 @@ export class VThermoDeviceCalculator extends DeviceCalculator {
             if (thermostat.targetSettings.offset) {
                 targetTemp += thermostat.targetSettings.offset;
             }
-            if (thermostat.targetSettings.min && targetTemp < thermostat.targetSettings.min) {
+            if (typeof thermostat.targetSettings.min === 'number' && targetTemp < thermostat.targetSettings.min) {
                 targetTemp = thermostat.targetSettings.min;
-            } else if (thermostat.targetSettings.max && targetTemp > thermostat.targetSettings.max) {
+            } else if (
+                typeof thermostat.targetSettings.max === 'number' &&
+                targetTemp > thermostat.targetSettings.max
+            ) {
                 targetTemp = thermostat.targetSettings.max;
             }
         }
@@ -399,7 +402,7 @@ export class VThermoDeviceCalculator extends DeviceCalculator {
         } else if (motionAlarm) {
             onoff = true;
         } else {
-            const hysteresis = deviceSettings.hysteresis || 0.5;
+            const hysteresis = deviceSettings.hysteresis ?? 0.5;
             const invert = deviceSettings.invert;
             if (temperature > targetTemperature + hysteresis) {
                 onoff = invert === true;

--- a/tasks/expected-failures/06-zero-target-temperature-limit.md
+++ b/tasks/expected-failures/06-zero-target-temperature-limit.md
@@ -1,5 +1,7 @@
 # Honor zero target-temperature limits
 
+- Status: Completed 2026-07-20
+
 ## Problem
 
 `VThermoDeviceCalculator.calculateTargetTemperature()` checks target minimum and maximum settings using truthiness. A configured boundary of `0` is treated as if it were absent, allowing propagated targets to cross the saved limit.
@@ -25,3 +27,7 @@ Test boundaries explicitly for `undefined` rather than truthiness. Review the of
 - Undefined limits do not clamp.
 - Change the related test from `it.fails` to `it` and add maximum-zero coverage.
 - `npm test`, `npm run test:coverage`, `npm run lint`, and `npm run build` pass.
+
+## Resolution
+
+Target minimum and maximum checks now test for numeric values instead of truthiness. Zero and negative boundaries clamp propagated targets correctly, while undefined limits remain inactive. The zero-minimum expected-failure test is now a normal regression test, with additional zero-maximum, negative-boundary, and undefined-limit coverage.

--- a/tasks/github-issues/58-zero-hysteresis.md
+++ b/tasks/github-issues/58-zero-hysteresis.md
@@ -1,7 +1,7 @@
 # GitHub #58: Allow zero hysteresis
 
 - Issue: https://github.com/balmli/no.almli.thermostat/issues/58
-- Status: Confirmed bug
+- Status: Completed 2026-07-20
 - Priority: Normal
 
 ## Cause
@@ -23,3 +23,12 @@
 ## Done when
 
 An explicit zero switches at the target threshold, undefined values retain the existing defaults, documentation explains the tradeoff, and the full test suite passes.
+
+## Resolution
+
+- VThermo and VHumidity now use nullish defaults, preserving an explicitly configured zero hysteresis.
+- Zero hysteresis switches on either side of the target while retaining the current state exactly at the target.
+- Undefined hysteresis continues to use the existing VThermo default of 0.5 and VHumidity default of 1.
+- README and Homey setting hints warn that zero hysteresis can cause rapid switching and reduce equipment lifetime.
+- Regression tests cover zero, undefined defaults, and the existing positive hysteresis bands for both controllers.
+- The related zero target-temperature limit failure was fixed in the same branch and pull request.

--- a/tests/vhumidity-calculator.test.ts
+++ b/tests/vhumidity-calculator.test.ts
@@ -135,6 +135,19 @@ describe('VHumidityDeviceCalculator switching', () => {
         expect(calculator().resolveOnOff(device, 51, 50)).toBeUndefined();
     });
 
+    it('supports zero hysteresis without changing state exactly at the target', () => {
+        const device = makeVHumidity({deviceSettings: {hysteresis: 0}});
+        expect(calculator().resolveOnOff(device, 49.99, 50)).toBe(false);
+        expect(calculator().resolveOnOff(device, 50, 50)).toBeUndefined();
+        expect(calculator().resolveOnOff(device, 50.01, 50)).toBe(true);
+    });
+
+    it('uses the default hysteresis when the setting is undefined', () => {
+        const device = makeVHumidity({deviceSettings: {hysteresis: undefined}});
+        expect(calculator().resolveOnOff(device, 50.5, 50)).toBeUndefined();
+        expect(calculator().resolveOnOff(device, 51.01, 50)).toBe(true);
+    });
+
     it('reverses fan behavior for humidifiers', () => {
         const device = makeVHumidity({deviceSettings: {invert: true}});
         expect(calculator().resolveOnOff(device, 52, 50)).toBe(false);

--- a/tests/vthermo-calculator.test.ts
+++ b/tests/vthermo-calculator.test.ts
@@ -142,6 +142,19 @@ describe('VThermoDeviceCalculator switching', () => {
         expect(calculator().resolveOnOff(device, 20.5, 20)).toBeUndefined();
     });
 
+    it('supports zero hysteresis without changing state exactly at the target', () => {
+        const device = makeVThermo({deviceSettings: {hysteresis: 0}});
+        expect(calculator().resolveOnOff(device, 19.99, 20)).toBe(true);
+        expect(calculator().resolveOnOff(device, 20, 20)).toBeUndefined();
+        expect(calculator().resolveOnOff(device, 20.01, 20)).toBe(false);
+    });
+
+    it('uses the default hysteresis when the setting is undefined', () => {
+        const device = makeVThermo({deviceSettings: {hysteresis: undefined}});
+        expect(calculator().resolveOnOff(device, 19.75, 20)).toBeUndefined();
+        expect(calculator().resolveOnOff(device, 19.49, 20)).toBe(true);
+    });
+
     it('reverses threshold behavior when switching is inverted', () => {
         const device = makeVThermo({deviceSettings: {invert: true}});
         expect(calculator().resolveOnOff(device, 19, 20)).toBe(false);
@@ -248,11 +261,27 @@ describe('VThermoDeviceCalculator target propagation', () => {
         expect(calculator.calculateTargetTemperature(makeDevice(), 20)).toBe(20);
     });
 
-    it.fails('honors a zero minimum target temperature', () => {
+    it('honors a zero minimum target temperature', () => {
         const recipient = makeVThermo({targetSettings: {min: 0, max: 25}});
         expect(
             new VThermoDeviceCalculator(new Zones(), makeDevicesStub([])).calculateTargetTemperature(recipient, -5),
         ).toBe(0);
+    });
+
+    it('honors zero and negative maximum target temperatures', () => {
+        const calculator = new VThermoDeviceCalculator(new Zones(), makeDevicesStub([]));
+        expect(calculator.calculateTargetTemperature(makeVThermo({targetSettings: {max: 0}}), 5)).toBe(0);
+        expect(calculator.calculateTargetTemperature(makeVThermo({targetSettings: {min: -10, max: -1}}), 5)).toBe(-1);
+        expect(calculator.calculateTargetTemperature(makeVThermo({targetSettings: {min: -10, max: -1}}), -20)).toBe(
+            -10,
+        );
+    });
+
+    it('does not clamp target temperatures when limits are undefined', () => {
+        const recipient = makeVThermo({targetSettings: {min: undefined, max: undefined}});
+        expect(
+            new VThermoDeviceCalculator(new Zones(), makeDevicesStub([])).calculateTargetTemperature(recipient, -5),
+        ).toBe(-5);
     });
 
     it('updates enabled virtual thermostats in direct children and physical thermostats in deeper descendants', () => {


### PR DESCRIPTION
## Summary

- preserve an explicitly configured zero hysteresis for VThermo and VHumidity
- retain the current controller state exactly at the target while switching immediately on either side
- honor zero and negative propagated target-temperature limits
- document the rapid-switching and equipment-lifetime tradeoff in README and Homey setting hints

Fixes #58.

## Related expected failure

This PR also completes `tasks/expected-failures/06-zero-target-temperature-limit.md`, which is the same falsy-zero defect pattern and is required by the linked issue task.

## TDD coverage

The regression tests were added and observed failing before the production change. Coverage includes:

- zero, undefined-default, and positive hysteresis behavior for VThermo
- zero, undefined-default, and positive hysteresis behavior for VHumidity
- zero minimum and maximum target limits
- negative target limits and undefined limits

The former zero-minimum `it.fails` test is now a normal passing test.

## Verification

- `npm test`: 101 passed, 7 expected failures
- `npm run test:coverage`: configured thresholds pass
- `npm run lint`: pass
- `npm run build`: pass
- Homey publish validation: pass

The existing Homey validation warnings for the reserved `zone_sensors` and `zone_other` setting prefixes remain unchanged.

## Hardware scope

The threshold behavior is deterministic calculation logic and is covered by unit tests. It has not been exercised on physical Homey hardware in this change. Zero hysteresis may cause rapid relay switching, so the setting hints and README explicitly warn users about that tradeoff.