### PR TITLE
Fix stale temperature subscriptions

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -22,6 +22,12 @@ module.exports = class VThermoApp extends Homey.App {
     calculator!: Calculator;
     _refreshTimeout: any;
     _lastNumRunningDevices?: number;
+    private readonly _deviceCreateListener = this._onDeviceCreate.bind(this);
+    private readonly _deviceUpdateListener = this._onDeviceUpdate.bind(this);
+    private readonly _deviceDeleteListener = this._onDeviceDelete.bind(this);
+    private readonly _zoneCreateListener = this._onZoneCreate.bind(this);
+    private readonly _zoneUpdateListener = this._onZoneUpdate.bind(this);
+    private readonly _zoneDeleteListener = this._onZoneDelete.bind(this);
 
     async onInit(): Promise<void> {
         this.logger = new Logger({
@@ -43,7 +49,7 @@ module.exports = class VThermoApp extends Homey.App {
         this.calculator.destroy();
         this.devicesObj.destroy();
         this.zonesObj.destroy();
-        this.destroyHomeyApi();
+        await this.destroyHomeyApi();
     }
 
     private async initFlows() {
@@ -149,41 +155,61 @@ module.exports = class VThermoApp extends Homey.App {
     }
 
     private async destroyHomeyApi(): Promise<void> {
+        const homeyApi = this.homeyApi;
+        if (!homeyApi) {
+            return;
+        }
+        this.homeyApi = undefined;
+        this.homeyApiCreated = undefined;
+
         try {
-            if (this.homeyApi) {
-                this.homeyApi.devices.removeListener('device.create', this._onDeviceCreate.bind(this));
-                this.homeyApi.devices.removeListener('device.update', this._onDeviceUpdate.bind(this));
-                this.homeyApi.devices.removeListener('device.delete', this._onDeviceDelete.bind(this));
-                await this.homeyApi.devices.disconnect();
-                this.homeyApi.zones.removeListener('zone.create', this._onZoneCreate.bind(this));
-                this.homeyApi.zones.removeListener('zone.update', this._onZoneUpdate.bind(this));
-                this.homeyApi.zones.removeListener('zone.delete', this._onZoneDelete.bind(this));
-                await this.homeyApi.zones.disconnect();
-                await this.homeyApi.destroy();
-                this.homeyApi = undefined;
-                this.logger.debug(`HomeyAPI instance destroyed`);
-            }
+            homeyApi.devices.removeListener('device.create', this._deviceCreateListener);
+            homeyApi.devices.removeListener('device.update', this._deviceUpdateListener);
+            homeyApi.devices.removeListener('device.delete', this._deviceDeleteListener);
         } catch (err) {
-            this.homeyApi = undefined;
+            this.logger.error(`Removing HomeyAPI device listeners failed`, err);
+        }
+        try {
+            homeyApi.zones.removeListener('zone.create', this._zoneCreateListener);
+            homeyApi.zones.removeListener('zone.update', this._zoneUpdateListener);
+            homeyApi.zones.removeListener('zone.delete', this._zoneDeleteListener);
+        } catch (err) {
+            this.logger.error(`Removing HomeyAPI zone listeners failed`, err);
+        }
+        try {
+            await homeyApi.devices.disconnect();
+        } catch (err) {
+            this.logger.error(`Disconnecting HomeyAPI devices failed`, err);
+        }
+        try {
+            await homeyApi.zones.disconnect();
+        } catch (err) {
+            this.logger.error(`Disconnecting HomeyAPI zones failed`, err);
+        }
+        try {
+            await homeyApi.destroy();
+        } catch (err) {
             this.logger.error(`Destroying HomeyAPI failed`, err);
         }
+        this.logger.debug(`HomeyAPI instance destroyed`);
     }
 
     private async createHomeyApi(): Promise<void> {
         try {
             this.homeyApi = await HomeyAPI.createAppAPI({homey: this.homey, debug: false});
             await this.homeyApi.devices.connect();
-            this.homeyApi.devices.on('device.create', this._onDeviceCreate.bind(this));
-            this.homeyApi.devices.on('device.update', this._onDeviceUpdate.bind(this));
-            this.homeyApi.devices.on('device.delete', this._onDeviceDelete.bind(this));
+            this.homeyApi.devices.on('device.create', this._deviceCreateListener);
+            this.homeyApi.devices.on('device.update', this._deviceUpdateListener);
+            this.homeyApi.devices.on('device.delete', this._deviceDeleteListener);
             await this.homeyApi.zones.connect();
-            this.homeyApi.zones.on('zone.create', this._onZoneCreate.bind(this));
-            this.homeyApi.zones.on('zone.update', this._onZoneUpdate.bind(this));
-            this.homeyApi.zones.on('zone.delete', this._onZoneDelete.bind(this));
+            this.homeyApi.zones.on('zone.create', this._zoneCreateListener);
+            this.homeyApi.zones.on('zone.update', this._zoneUpdateListener);
+            this.homeyApi.zones.on('zone.delete', this._zoneDeleteListener);
             this.homeyApiCreated = Date.now();
             this.logger.verbose(`HomeyAPIApp instance created`);
         } catch (err) {
             this.logger.error(`Creating HomeyAPIApp failed`, err);
+            await this.destroyHomeyApi();
         }
     }
 
@@ -315,18 +341,16 @@ module.exports = class VThermoApp extends Homey.App {
 
     private async _onDeviceUpdate(device: HomeyAPIV3Local.ManagerDevices.Device): Promise<void> {
         this.logger.silly(`Device update: ${device.driverId}:${device.class} - ${device.id} - ${device.name}`);
-        if (this.devicesObj.validAndSupported(device)) {
-            try {
-                const current = this.devicesObj.getDevice(device.id);
-                if (!current && !device.makeCapabilityInstance) {
-                    const now = Date.now();
-                    device = await this.getDevice(device.id);
-                    this.logger?.debug(`Fetched device: ${device.id} ${device.name}. (${Date.now() - now} ms.)`);
-                }
-                this.devicesObj.createOrUpdateDevice(device);
-            } catch (err) {
-                this.logger.error('Device update failed', err);
+        try {
+            const current = this.devicesObj.getDevice(device.id);
+            if (this.devicesObj.validAndSupported(device) && !current && !device.makeCapabilityInstance) {
+                const now = Date.now();
+                device = await this.getDevice(device.id);
+                this.logger?.debug(`Fetched device: ${device.id} ${device.name}. (${Date.now() - now} ms.)`);
             }
+            this.devicesObj.createOrUpdateDevice(device);
+        } catch (err) {
+            this.logger.error('Device update failed', err);
         }
     }
 

--- a/lib/Devices.ts
+++ b/lib/Devices.ts
@@ -43,6 +43,7 @@ export class Devices {
         for (const ci of this.capabilityInstances.values()) {
             ci.destroy();
         }
+        this.capabilityInstances.clear();
         this.pendingPhysicalUpdates.clear();
     }
 
@@ -99,10 +100,18 @@ export class Devices {
      */
     registerDevices(devicesAsMap?: {[key: string]: HomeyAPIV3Local.ManagerDevices.Device}): void {
         if (devicesAsMap) {
+            const registeredDeviceIds = new Set<string>();
             for (const key in devicesAsMap) {
                 if (devicesAsMap.hasOwnProperty(key)) {
                     const device = devicesAsMap[key];
-                    this.registerDevice(device);
+                    if (this.registerDevice(device)) {
+                        registeredDeviceIds.add(device.id);
+                    }
+                }
+            }
+            for (const device of [...this.devices]) {
+                if (!registeredDeviceIds.has(device.id)) {
+                    this.deleteDevice({id: device.id} as HomeyAPIV3Local.ManagerDevices.Device);
                 }
             }
             this.logger?.info(`Registered devices. (${this.devices.length} devices)`);
@@ -116,10 +125,14 @@ export class Devices {
      */
     createOrUpdateDevice(device: HomeyAPIV3Local.ManagerDevices.Device): Device | undefined {
         if (!this.validAndSupported(device)) {
+            if (device?.id && this.getDevice(device.id)) {
+                this.deleteDevice(device);
+            }
             return;
         }
         const current = this.getDevice(device.id);
         if (current) {
+            this.replaceCapabilityInstances(device, current);
             this.updateDeviceData(current, device);
             this.calculator?.startCalculation();
             return current;
@@ -153,6 +166,7 @@ export class Devices {
                 }
             }
             this.logger?.debug(`Deleted device: ${device.id}. (${this.devices.length} devices)`);
+            this.calculator?.startCalculation();
         }
     }
 
@@ -167,11 +181,14 @@ export class Devices {
             device.available = newDevice.available;
             this.logger?.debug(`Updated device data: ${device.id}`, device);
         }
-        if (Devices.deviceCapabilitiesChanged(device, updatedDevice)) {
-            device.capabilities = newDevice.capabilities;
-            device.capabilitiesObj = newDevice.capabilitiesObj;
+        if (
+            Devices.deviceCapabilitiesChanged(device, updatedDevice) ||
+            Devices.deviceCapabilityValuesChanged(device, newDevice)
+        ) {
             this.logger?.debug(`Updated device capabilities: ${device.id}`, device);
         }
+        device.capabilities = newDevice.capabilities;
+        device.capabilitiesObj = newDevice.capabilitiesObj;
         device.temperatureSettings = newDevice.temperatureSettings;
         device.deviceSettings = newDevice.deviceSettings;
         device.targetSettings = newDevice.targetSettings;
@@ -197,6 +214,13 @@ export class Devices {
             device.capabilities?.length !== updatedDevice.capabilities?.length ||
             device.capabilities?.slice().sort().join(',') !== updatedDevice.capabilities?.slice().sort().join(',')
         );
+    }
+
+    private static deviceCapabilityValuesChanged(device: Device, updatedDevice: Device): boolean {
+        return [...(updatedDevice.capabilitiesObj?.entries() ?? [])].some(([capabilityId, capability]) => {
+            const current = device.capabilitiesObj?.get(capabilityId);
+            return !current || current.value !== capability.value || current.lastUpdated !== capability.lastUpdated;
+        });
     }
 
     private static filterDeviceClass = (d: Device, deviceClass?: DeviceClass): boolean => {
@@ -268,16 +292,7 @@ export class Devices {
 
     private registerDevice(device: HomeyAPIV3Local.ManagerDevices.Device): Device | undefined {
         if (this.validAndSupported(device)) {
-            let create = !device.makeCapabilityInstance;
-            if (!!device.makeCapabilityInstance) {
-                const capabilities = device.capabilitiesObj;
-                for (const capabilityId in capabilities) {
-                    if (capabilities.hasOwnProperty(capabilityId) && SUPPORTED_CAPABILITIES.includes(capabilityId)) {
-                        this.makeCapabilityInstance(device, capabilityId);
-                        create = true;
-                    }
-                }
-            }
+            const create = this.replaceCapabilityInstances(device, this.getDevice(device.id));
             if (create) {
                 const deviceId = device.id;
                 const idx = this.devices.findIndex(d => d.id === deviceId);
@@ -306,6 +321,7 @@ export class Devices {
             typeof device === 'object' &&
             !!device.id &&
             !!device.name &&
+            device.ready &&
             device.available &&
             !!device.capabilities &&
             !!device.capabilitiesObj;
@@ -313,6 +329,29 @@ export class Devices {
             this.logger?.silly(`Invalid device: ${device.id} - ${device.name}`);
         }
         return ret;
+    }
+
+    private replaceCapabilityInstances(device: HomeyAPIV3Local.ManagerDevices.Device, current?: Device): boolean {
+        const capabilities = device.capabilitiesObj;
+        const supportedCapabilityIds = Object.keys(capabilities).filter(capabilityId =>
+            SUPPORTED_CAPABILITIES.includes(capabilityId),
+        );
+        const supportedCapabilityIdSet = new Set(supportedCapabilityIds);
+
+        for (const capabilityId of current?.capabilitiesObj?.keys() ?? []) {
+            if (!supportedCapabilityIdSet.has(capabilityId)) {
+                this.destroyCapabilityInstance(capabilityIdFormat(device.id, capabilityId));
+            }
+        }
+
+        if (!device.makeCapabilityInstance) {
+            return true;
+        }
+
+        for (const capabilityId of supportedCapabilityIds) {
+            this.makeCapabilityInstance(device, capabilityId);
+        }
+        return supportedCapabilityIds.length > 0;
     }
 
     private supportedDevice(device: HomeyAPIV3Local.ManagerDevices.Device): boolean {
@@ -336,7 +375,9 @@ export class Devices {
                 this.capabilityInstanceListener(device, capabilityId, value),
             );
             this.capabilityInstances.set(deviceCapabilityId, capabilityInstance);
-            this.logger?.verbose(`Registered capability instance: ${device.id} ${device.name} ${capabilityId}`);
+            this.logger?.verbose(
+                `Registered capability instance: ${device.id} ${device.name} ${capabilityId} (${this.capabilityInstances.size} active)`,
+            );
         } catch (err) {
             this.logger?.error('Error creating capability instance: ' + capabilityId, err);
         }
@@ -353,7 +394,9 @@ export class Devices {
             if (deviz.hasChangedValue(capabilityId, value)) {
                 deviz.setLocalCapabilityValue(capabilityId, value);
                 this.calculator?.startCalculation();
-                this.logger?.debug(`Updated device capability: ${device.id} ${capabilityId}`);
+                this.logger?.debug(
+                    `Updated device capability: ${device.id} ${capabilityId} at ${new Date().toISOString()}`,
+                );
             }
         }
     }

--- a/lib/VThermoDeviceCalculator.ts
+++ b/lib/VThermoDeviceCalculator.ts
@@ -139,7 +139,7 @@ export class VThermoDeviceCalculator extends DeviceCalculator {
             } else if (tempSettings.calcMethod === CalcMethod.MIN) {
                 temperature = math.min(temperatures, tempSettings.measurementMaxAge);
             } else if (tempSettings.calcMethod === CalcMethod.MAX) {
-                ((temperature = math.max(temperatures)), tempSettings.measurementMaxAge);
+                temperature = math.max(temperatures, tempSettings.measurementMaxAge);
             } else if (tempSettings.calcMethod === CalcMethod.NEWEST) {
                 temperature = math.newest(temperatures);
             } else if (tempSettings.calcMethod === CalcMethod.MANUAL) {

--- a/lib/math.ts
+++ b/lib/math.ts
@@ -10,7 +10,7 @@ const values = (arr: any[], measurementMaxAge?: number) => {
                       ts: typeof v.lastUpdated === 'number' ? v.lastUpdated : new Date(v.lastUpdated).getTime(),
                   }))
                   .filter(v => !measurementMaxAge || Date.now() - v.ts < measurementMaxAge);
-    return vals.length < 1 ? newest(arr) : vals.map(v => v.value);
+    return vals.length < 1 ? [newest(arr)] : vals.map(v => v.value);
 };
 
 export const average = (arr: any[], measurementMaxAge?: number) => {

--- a/tasks/expected-failures/01-stale-measurement-fallback.md
+++ b/tasks/expected-failures/01-stale-measurement-fallback.md
@@ -1,5 +1,7 @@
 # Fix all-stale measurement fallback
 
+- Status: Completed 2026-07-20
+
 ## Problem
 
 When every reading is older than `measurementMaxAge`, `math.values()` returns the newest reading as a scalar. The aggregation functions (`average`, `min`, and `max`) expect `values()` to return an array, so the average path throws `TypeError: vals.reduce is not a function`.
@@ -27,3 +29,7 @@ Keep the return type of `values()` consistent by wrapping the newest value in an
 - Recent readings still exclude stale readings normally.
 - Change both related tests from `it.fails` to `it`.
 - `npm test`, `npm run test:coverage`, `npm run lint`, and `npm run build` pass.
+
+## Resolution
+
+The age-filter helper now always returns an array. When every value is stale, that array contains the single newest reading, so average, minimum, and maximum calculations share the intended fallback without throwing. Tests cover numeric and date-string timestamps, all three aggregations, the humidity calculation path, and a sole old reading.

--- a/tasks/expected-failures/05-vthermo-max-measurement-age.md
+++ b/tasks/expected-failures/05-vthermo-max-measurement-age.md
@@ -1,5 +1,7 @@
 # Apply measurement age to VThermo MAX calculations
 
+- Status: Completed 2026-07-20
+
 ## Problem
 
 The VThermo `MAX` branch calls `math.max(temperatures)` without passing `measurementMaxAge`. A comma expression evaluates the age setting separately and discards it. Stale high readings can therefore control the thermostat indefinitely.
@@ -24,3 +26,7 @@ Pass `tempSettings.measurementMaxAge` as the second argument to `math.max()`. En
 - The all-stale fallback uses the newest reading once task 01 is fixed.
 - Change the related test from `it.fails` to `it`.
 - `npm test`, `npm run test:coverage`, `npm run lint`, and `npm run build` pass.
+
+## Resolution
+
+The VThermo MAX branch now passes `measurementMaxAge` to `math.max()` instead of discarding it through a comma expression. A stale high reading is excluded when a recent value exists, and the shared all-stale fallback selects the newest reading when none remain within the configured age.

--- a/tasks/github-issues/52-stale-temperature-subscriptions.md
+++ b/tasks/github-issues/52-stale-temperature-subscriptions.md
@@ -1,7 +1,7 @@
 # GitHub #52: VThermo temperature stops updating
 
 - Issue: https://github.com/balmli/no.almli.thermostat/issues/52
-- Status: Investigation
+- Status: Completed 2026-07-20
 - Priority: High
 
 ## Report
@@ -22,11 +22,18 @@ Several users report that VThermo eventually shows a stale or incorrect temperat
 5. Add tests for subscription replacement, reconnect, unavailable-to-available transitions, and multi-sensor updates.
 6. Improve diagnostic logging around last capability event, last refresh, sensor timestamps, and active subscription count.
 
-## Information needed
-
-- Diagnostic report captured immediately while values are stale, before restarting.
-- Homey model/firmware, app version, calculation method, sensor list, and old-measurement setting.
-
 ## Done when
 
 A long-running subscription test reproduces and fixes the stale state, or diagnostics can distinguish an upstream sensor outage from a VThermo subscription/cache failure.
+
+## Resolution
+
+- Device refreshes now replace supported capability instances and destroy subscriptions for capabilities or devices that disappeared from the authoritative snapshot.
+- Unavailable or not-ready devices are removed from the active model and recreated with fresh subscriptions when they recover.
+- Refreshed API capability values replace stale cached values even when the capability list itself did not change.
+- Homey API device and zone listeners now use stable callback references, partial connection failures are fully destroyed, and app shutdown awaits manager disconnection.
+- Subscription logs include the active instance count, and capability-event logs include an event timestamp.
+- The related all-stale aggregation and VThermo MAX age-filter failures were fixed in the same branch and pull request.
+- Regression tests cover subscription replacement, removed capabilities, full-snapshot removal, unavailable-to-available recovery, stable API listeners, partial initialization, awaited shutdown, stale fallback, and MAX age filtering.
+
+These tests exercise API-shaped manager resources and lifecycle behavior locally. They do not prove event delivery from every physical sensor app or Homey generation; an upstream sensor that stops publishing will still retain its last known reading according to the configured maximum-age behavior.

--- a/tests/app-homey-api.test.ts
+++ b/tests/app-homey-api.test.ts
@@ -1,0 +1,100 @@
+import {beforeAll, describe, expect, it, vi} from 'vitest';
+
+const createAppAPI = vi.fn();
+
+vi.mock('homey-api', () => ({
+    HomeyAPI: {createAppAPI},
+}));
+
+let VThermoApp: any;
+
+beforeAll(async () => {
+    const appModule = await import('../app.js');
+    VThermoApp = appModule.default ?? appModule;
+});
+
+function makeManager(connect = vi.fn().mockResolvedValue(undefined)) {
+    return {
+        connect,
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        on: vi.fn(),
+        removeListener: vi.fn(),
+    };
+}
+
+function makeApi(devices = makeManager(), zones = makeManager()) {
+    return {
+        devices,
+        zones,
+        destroy: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function makeApp() {
+    const app = new VThermoApp();
+    app.homey = {clearTimeout: vi.fn()};
+    app.logger = {debug: vi.fn(), error: vi.fn(), verbose: vi.fn()};
+    return app;
+}
+
+describe('Homey API manager lifecycle', () => {
+    it('removes the exact device and zone listener functions that were registered', async () => {
+        const api = makeApi();
+        createAppAPI.mockResolvedValueOnce(api);
+        const app = makeApp();
+
+        await app.createHomeyApi();
+        await app.destroyHomeyApi();
+
+        for (const event of ['device.create', 'device.update', 'device.delete']) {
+            const registered = api.devices.on.mock.calls.find((call: any[]) => call[0] === event)?.[1];
+            expect(api.devices.removeListener).toHaveBeenCalledWith(event, registered);
+        }
+        for (const event of ['zone.create', 'zone.update', 'zone.delete']) {
+            const registered = api.zones.on.mock.calls.find((call: any[]) => call[0] === event)?.[1];
+            expect(api.zones.removeListener).toHaveBeenCalledWith(event, registered);
+        }
+    });
+
+    it('destroys a partially connected API instead of retaining it', async () => {
+        const devices = makeManager();
+        const zones = makeManager(vi.fn().mockRejectedValue(new Error('zone connection failed')));
+        const api = makeApi(devices, zones);
+        createAppAPI.mockResolvedValueOnce(api);
+        const app = makeApp();
+
+        await app.createHomeyApi();
+
+        expect(app.homeyApi).toBeUndefined();
+        expect(devices.disconnect).toHaveBeenCalledOnce();
+        expect(zones.disconnect).toHaveBeenCalledOnce();
+        expect(api.destroy).toHaveBeenCalledOnce();
+    });
+
+    it('awaits API teardown during app shutdown', async () => {
+        let finishDisconnect!: () => void;
+        const devices = makeManager();
+        devices.disconnect.mockReturnValue(
+            new Promise<void>(resolve => {
+                finishDisconnect = resolve;
+            }),
+        );
+        const api = makeApi(devices);
+        const app = makeApp();
+        app.homeyApi = api;
+        app.calculator = {destroy: vi.fn()};
+        app.devicesObj = {destroy: vi.fn()};
+        app.zonesObj = {destroy: vi.fn()};
+
+        let completed = false;
+        const shutdown = app.onUninit().then(() => {
+            completed = true;
+        });
+        await Promise.resolve();
+        expect(completed).toBe(false);
+
+        finishDisconnect();
+        await shutdown;
+        expect(api.destroy).toHaveBeenCalledOnce();
+    });
+});

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -125,6 +125,80 @@ describe('Devices registry', () => {
         expect(destroys.every(destroy => destroy.mock.calls.length === 1)).toBe(true);
     });
 
+    it('replaces capability subscriptions when an API device is refreshed', () => {
+        let firstListener!: (value: unknown) => void;
+        let secondListener!: (value: unknown) => void;
+        const firstDestroy = vi.fn();
+        const secondDestroy = vi.fn();
+        const first = makeApiDevice({id: 'sensor', capabilities: {measure_temperature: 20}});
+        first.makeCapabilityInstance = vi.fn((_id: string, listener: (value: unknown) => void) => {
+            firstListener = listener;
+            return {destroy: firstDestroy};
+        });
+        const second = makeApiDevice({id: 'sensor', capabilities: {measure_temperature: 21}});
+        second.makeCapabilityInstance = vi.fn((_id: string, listener: (value: unknown) => void) => {
+            secondListener = listener;
+            return {destroy: secondDestroy};
+        });
+        const calculator = {startCalculation: vi.fn()};
+        const devices = new Devices({sensor: first} as any);
+        devices.setCalculator(calculator as any);
+
+        expect(firstListener).toBeTypeOf('function');
+        devices.createOrUpdateDevice(second);
+        expect(firstDestroy).toHaveBeenCalledOnce();
+        expect(secondListener).toBeTypeOf('function');
+        expect(devices.getDevice('sensor')?.getLocalCapabilityValue('measure_temperature').value).toBe(21);
+        secondListener(22);
+        expect(devices.getDevice('sensor')?.getLocalCapabilityValue('measure_temperature').value).toBe(22);
+        expect(calculator.startCalculation).toHaveBeenCalledTimes(2);
+    });
+
+    it('destroys subscriptions for removed capabilities and snapshot devices', () => {
+        const destroys = new Map<string, ReturnType<typeof vi.fn>>();
+        const sensor = makeApiDevice({
+            id: 'sensor',
+            capabilities: {measure_temperature: 20, alarm_motion: false},
+        });
+        sensor.makeCapabilityInstance = vi.fn((id: string) => {
+            const destroy = vi.fn();
+            destroys.set(`sensor:${id}`, destroy);
+            return {destroy};
+        });
+        const removed = makeApiDevice({id: 'removed', capabilities: {measure_temperature: 10}});
+        removed.makeCapabilityInstance = vi.fn((id: string) => {
+            const destroy = vi.fn();
+            destroys.set(`removed:${id}`, destroy);
+            return {destroy};
+        });
+        const devices = new Devices({sensor, removed} as any);
+        const refreshed = makeApiDevice({id: 'sensor', capabilities: {measure_temperature: 21}});
+        refreshed.makeCapabilityInstance = vi.fn(() => ({destroy: vi.fn()}));
+
+        devices.registerDevices({sensor: refreshed} as any);
+
+        expect(destroys.get('sensor:alarm_motion')).toHaveBeenCalledOnce();
+        expect(destroys.get('removed:measure_temperature')).toHaveBeenCalledOnce();
+        expect(devices.getDevice('removed')).toBeUndefined();
+    });
+
+    it('removes an unavailable device and recreates it when available again', () => {
+        const destroy = vi.fn();
+        const available = makeApiDevice({id: 'sensor', capabilities: {measure_temperature: 20}});
+        available.makeCapabilityInstance = vi.fn(() => ({destroy}));
+        const devices = new Devices({sensor: available} as any);
+        const unavailable = {...available, available: false};
+
+        devices.createOrUpdateDevice(unavailable);
+        expect(devices.getDevice('sensor')).toBeUndefined();
+        expect(destroy).toHaveBeenCalledOnce();
+
+        const restored = makeApiDevice({id: 'sensor', capabilities: {measure_temperature: 21}});
+        restored.makeCapabilityInstance = vi.fn(() => ({destroy: vi.fn()}));
+        expect(devices.createOrUpdateDevice(restored)).toBeDefined();
+        expect(devices.getDevice('sensor')?.getLocalCapabilityValue('measure_temperature').value).toBe(21);
+    });
+
     it('creates, updates and deletes devices', () => {
         const calculator = {startCalculation: vi.fn()};
         const devices = new Devices();
@@ -135,7 +209,7 @@ describe('Devices registry', () => {
         devices.deleteDevice(created);
         devices.deleteDevice(created);
         expect(devices.getDevice('device')).toBeUndefined();
-        expect(calculator.startCalculation).toHaveBeenCalledTimes(2);
+        expect(calculator.startCalculation).toHaveBeenCalledTimes(3);
     });
 });
 

--- a/tests/math.test.ts
+++ b/tests/math.test.ts
@@ -34,10 +34,15 @@ describe('math', () => {
         vi.useRealTimers();
     });
 
-    it.fails('falls back to the newest reading when all readings are stale', () => {
+    it('falls back to the newest reading when all readings are stale', () => {
         vi.setSystemTime(NOW);
-        const values = [new DeviceCapability(10, NOW - 20_000), new DeviceCapability(15, NOW - 10_000)];
+        const values = [
+            new DeviceCapability(10, NOW - 20_000),
+            {value: 15, lastUpdated: new Date(NOW - 10_000).toISOString()},
+        ];
         expect(math.average(values, 1000)).toBe(15);
+        expect(math.min(values, 1000)).toBe(15);
+        expect(math.max(values, 1000)).toBe(15);
         vi.useRealTimers();
     });
 

--- a/tests/mocks/homey.ts
+++ b/tests/mocks/homey.ts
@@ -1,3 +1,10 @@
+class App {
+    homey: any;
+
+    log() {}
+    error() {}
+}
+
 class Device {
     log() {}
     error() {}
@@ -8,4 +15,4 @@ class Driver {
     error() {}
 }
 
-export default {Device, Driver};
+export default {App, Device, Driver};

--- a/tests/vhumidity-calculator.test.ts
+++ b/tests/vhumidity-calculator.test.ts
@@ -75,7 +75,7 @@ describe('VHumidityDeviceCalculator measurements', () => {
         vi.useRealTimers();
     });
 
-    it.fails('falls back to the newest reading when every reading is old', () => {
+    it('falls back to the newest reading when every reading is old', () => {
         vi.useFakeTimers();
         vi.setSystemTime(NOW);
         const virtual = makeVHumidity({

--- a/tests/vthermo-calculator.test.ts
+++ b/tests/vthermo-calculator.test.ts
@@ -113,7 +113,7 @@ describe('VThermoDeviceCalculator temperature inputs', () => {
         expect(request).toMatchObject({value: null});
     });
 
-    it.fails('applies maximum-age filtering to the MAX calculation method', () => {
+    it('applies maximum-age filtering to the MAX calculation method', () => {
         vi.useFakeTimers();
         vi.setSystemTime(NOW);
         const calculator = new VThermoDeviceCalculator(new Zones(), makeDevicesStub([]));


### PR DESCRIPTION
## Summary

- replace Homey capability subscriptions when API device resources are refreshed
- reconcile removed, unavailable, and not-ready devices from authoritative snapshots and recreate subscriptions after recovery
- refresh cached capability values even when capability membership is unchanged
- use stable Homey API manager listener references, clean up partial connections, and await shutdown
- fix all-stale measurement fallback and apply maximum-age filtering to VThermo MAX calculations
- add subscription count and capability-event timing diagnostics

Fixes #52.

## Related expected failures

This PR also completes:

- `tasks/expected-failures/01-stale-measurement-fallback.md`
- `tasks/expected-failures/05-vthermo-max-measurement-age.md`

Both are directly connected to stale or incorrect measurements and are required by the GitHub issue task.

## TDD coverage

The regression tests were added and observed failing before the production changes. Coverage includes:

- replacing capability instances and refreshing cached values
- destroying removed capability and device subscriptions
- full-snapshot reconciliation
- unavailable-to-available recovery
- exact manager listener removal
- partial API initialization cleanup and awaited shutdown
- average/min/max fallback when every reading is stale
- VThermo MAX age filtering

## Verification

- `npm test`: 110 passed, 4 expected failures
- `npm run test:coverage`: configured thresholds pass; 93.04% statements and 81.59% branches
- `npm run lint`: pass
- `npm run build`: pass
- Homey publish validation: pass

The existing Homey validation warnings for the reserved `zone_sensors` and `zone_other` setting prefixes remain unchanged.

## Hardware scope

The manager behavior is covered with API-shaped resources and lifecycle tests. This change has not been exercised on physical Homey hardware or every third-party sensor app. If an upstream sensor itself stops publishing values, VThermo still follows the configured maximum-age behavior and uses the newest known value when all readings are stale.