### PR TITLE
Fix VThermo reactivating after switch-off

### DIFF
--- a/.homeycompose/drivers/settings/onoff_enabled.json
+++ b/.homeycompose/drivers/settings/onoff_enabled.json
@@ -6,6 +6,6 @@
   },
   "value": true,
   "hint": {
-    "en": "By unchecking this switch, the device cannot be turned off."
+    "en": "When unchecked, the device cannot be turned off and its on/off switch will remain on."
   }
 }

--- a/app.json
+++ b/app.json
@@ -634,7 +634,7 @@
               },
               "value": true,
               "hint": {
-                "en": "By unchecking this switch, the device cannot be turned off."
+                "en": "When unchecked, the device cannot be turned off and its on/off switch will remain on."
               }
             }
           ]
@@ -1265,7 +1265,7 @@
               },
               "value": true,
               "hint": {
-                "en": "By unchecking this switch, the device cannot be turned off."
+                "en": "When unchecked, the device cannot be turned off and its on/off switch will remain on."
               }
             }
           ]

--- a/app.ts
+++ b/app.ts
@@ -137,6 +137,15 @@ module.exports = class VThermoApp extends Homey.App {
     }
 
     /**
+     * Update mapped settings for a local virtual device by data id.
+     * @param dataId
+     * @param settings complete Homey settings object
+     */
+    updateSettingsByDataId(dataId: string, settings: any): void {
+        this.devicesObj.updateSettingsByDataId(dataId, settings);
+    }
+
+    /**
      * Start calculation, with an optional delay.
      * @param delay delay in ms.
      */

--- a/drivers/VThermo/device.ts
+++ b/drivers/VThermo/device.ts
@@ -58,17 +58,11 @@ module.exports = class VThermoDevice extends BaseDevice {
         if (err) {
             throw new Error(err);
         } else {
-            this.homey.setTimeout(async () => {
-                if (
-                    changedKeys.includes('target_min_temp') ||
-                    changedKeys.includes('target_max_temp') ||
-                    changedKeys.includes('target_diff_temp')
-                ) {
-                    //await this.homey.app.updateAllTargetTemperatures(this);
-                }
-                // @ts-ignore
-                this.homey.app.startCalculation();
-            }, 1000);
+            // Keep the Web API-backed model in sync before calculation. Waiting for
+            // a later device.update event can leave onoff_enabled stale long enough
+            // for an off device to be evaluated as if switching were disabled.
+            // @ts-ignore
+            this.homey.app.updateSettingsByDataId(this.getData().id, newSettings);
         }
     }
 

--- a/lib/DeviceMapper.ts
+++ b/lib/DeviceMapper.ts
@@ -21,11 +21,15 @@ export class DeviceMapper {
         d.available = i.available;
         d.capabilities = i.capabilities;
         d.capabilitiesObj = DeviceMapper.mapCapabilities(i.capabilitiesObj);
-        d.temperatureSettings = TemperatureSettingsMapper.map(i.driverId, i.settings);
-        d.deviceSettings = DeviceSettingsMapper.map(i.driverId, i.settings);
-        d.targetSettings = TargetSettingsMapper.map(i.driverId, i.settings);
-        d.humiditySettings = HumiditySettingsMapper.map(i.driverId, i.settings);
+        DeviceMapper.mapSettings(d, i.driverId, i.settings);
         return d;
+    }
+
+    static mapSettings(device: Device, driverId?: string, settings?: any): void {
+        device.temperatureSettings = TemperatureSettingsMapper.map(driverId, settings);
+        device.deviceSettings = DeviceSettingsMapper.map(driverId, settings);
+        device.targetSettings = TargetSettingsMapper.map(driverId, settings);
+        device.humiditySettings = HumiditySettingsMapper.map(driverId, settings);
     }
 
     private static mapCapabilities(caps: any): DeviceCapabilities {

--- a/lib/Devices.ts
+++ b/lib/Devices.ts
@@ -95,6 +95,22 @@ export class Devices {
     }
 
     /**
+     * Update mapped settings for a local virtual device and start calculation.
+     * @param dataId
+     * @param settings complete Homey settings object
+     */
+    updateSettingsByDataId(dataId: string, settings: any): void {
+        const device = this.getDeviceByDataId(dataId);
+        if (device) {
+            DeviceMapper.mapSettings(device, device.driverId, settings);
+            this.calculator?.startCalculation(1);
+            this.logger?.debug(`Updated device settings by data id: ${device.id}`);
+        } else {
+            this.logger?.warn(`Update settings by data id: unknown device: ${dataId}`);
+        }
+    }
+
+    /**
      * Register devices from a map of devices.
      * @param devicesAsMap
      */

--- a/tasks/github-issues/55-vthermo-reactivates-after-switch-off.md
+++ b/tasks/github-issues/55-vthermo-reactivates-after-switch-off.md
@@ -1,7 +1,7 @@
 # GitHub #55: VThermo immediately reactivates after switch-off
 
 - Issue: https://github.com/balmli/no.almli.thermostat/issues/55
-- Status: Investigation
+- Status: Completed 2026-07-20
 - Priority: High
 
 ## Report
@@ -20,12 +20,16 @@ When Advanced Settings → `On / off enabled` is unchecked, the capability liste
 4. Add regression tests for switch-off, app refresh, setting changes, and repeated Flow writes.
 5. Review whether the setting name and hint make the forced-on behavior sufficiently clear.
 
-## Information needed
-
-- Whether `On / off enabled` is checked when the issue occurs.
-- A fresh diagnostic report captured during the immediate reactivation.
-- Whether the switch is changed by UI, Flow, or script.
-
 ## Done when
 
 Switch-off remains stable whenever on/off control is enabled, while the intentionally disabled switch behavior remains clear and tested.
+
+## Resolution
+
+- VThermo settings changes now update the app's mapped device settings immediately instead of waiting for a later Homey Web API `device.update` event.
+- Recalculation is scheduled only after the complete new settings object has been mapped, preventing a newly enabled on/off switch from being evaluated with the stale disabled value.
+- The intentional behavior remains unchanged when `On / off enabled` is unchecked: switch-off is rejected and the device switch returns to on.
+- The setting hint now explicitly says that the on/off switch remains on while switching is disabled.
+- Regression tests cover stable switch-off when enabled, forced-on behavior when disabled, and immediate settings-cache refresh before recalculation.
+
+The tests exercise the Homey device callback and API-shaped local registry in isolation. A real Homey timing test remains outside the automated suite.

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -104,6 +104,25 @@ describe('Devices registry', () => {
         expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('unknown device'));
     });
 
+    it('updates mapped virtual-device settings immediately by local data id', () => {
+        const api = makeApiDevice({
+            id: 'virtual',
+            dataId: 'data-id',
+            driverId: DRIVER_VTHERMO,
+            capabilities: {onoff: false},
+        });
+        api.settings = {onoff_enabled: false};
+        const calculator = {startCalculation: vi.fn()};
+        const devices = new Devices({api} as any);
+        devices.setCalculator(calculator as any);
+
+        devices.updateSettingsByDataId('data-id', {onoff_enabled: true});
+
+        expect(devices.getDevice('virtual')?.deviceSettings?.onoffEnabled).toBe(true);
+        expect(calculator.startCalculation).toHaveBeenCalledOnce();
+        expect(calculator.startCalculation).toHaveBeenCalledWith(1);
+    });
+
     it('subscribes to supported capabilities, reacts to changes and destroys subscriptions', () => {
         const callbacks = new Map<string, (value: unknown) => void>();
         const destroys: ReturnType<typeof vi.fn>[] = [];

--- a/tests/vthermo-device.test.ts
+++ b/tests/vthermo-device.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it, vi} from 'vitest';
+import * as VThermoDeviceModule from '../drivers/VThermo/device';
+
+const VThermoDevice = (VThermoDeviceModule as any).default ?? VThermoDeviceModule;
+
+function makeDevice({onoffEnabled, onoff}: {onoffEnabled: boolean; onoff: boolean}) {
+    const listeners = new Map<string, (value: unknown, opts: unknown) => Promise<void>>();
+    const updateSettingsByDataId = vi.fn();
+    const setCapabilityValue = vi.fn().mockResolvedValue(undefined);
+    const device = Object.assign(Object.create(VThermoDevice.prototype), {
+        homey: {
+            __: vi.fn().mockReturnValue('Switching disabled'),
+            app: {updateByDataId: vi.fn(), updateSettingsByDataId},
+            setTimeout: vi.fn(),
+        },
+        logger: {error: vi.fn(), info: vi.fn()},
+        getData: vi.fn().mockReturnValue({id: 'data-id'}),
+        getSetting: vi.fn().mockReturnValue(onoffEnabled),
+        getCapabilityValue: vi.fn().mockReturnValue(onoff),
+        setCapabilityValue,
+        getCapabilityOptions: vi.fn().mockReturnValue({min: 1, max: 40, step: 0.5, decimals: 1}),
+        setCapabilityOptions: vi.fn().mockResolvedValue(undefined),
+        registerCapabilityListener: vi.fn((capabilityId, listener) => listeners.set(capabilityId, listener)),
+    });
+    return {device, listeners, setCapabilityValue, updateSettingsByDataId};
+}
+
+describe('VThermo Homey device', () => {
+    it('keeps switch-off stable when on/off control is enabled', async () => {
+        const {device, listeners, setCapabilityValue} = makeDevice({onoffEnabled: true, onoff: true});
+        await device.initialize();
+
+        await expect(listeners.get('onoff')!(false, {})).resolves.toBeUndefined();
+        expect(setCapabilityValue).not.toHaveBeenCalled();
+    });
+
+    it('restores on and rejects switch-off when on/off control is disabled', async () => {
+        const {device, listeners, setCapabilityValue} = makeDevice({onoffEnabled: false, onoff: false});
+        await device.initialize();
+
+        await expect(listeners.get('onoff')!(false, {})).rejects.toThrow('Switching disabled');
+        expect(setCapabilityValue).toHaveBeenCalledWith('onoff', true);
+    });
+
+    it('refreshes mapped settings before recalculating after a settings change', async () => {
+        const {device, updateSettingsByDataId} = makeDevice({onoffEnabled: true, onoff: false});
+        const newSettings = {onoff_enabled: true, target_step: 'step050'};
+
+        await device.onSettings({oldSettings: {onoff_enabled: false}, newSettings, changedKeys: ['onoff_enabled']});
+
+        expect(updateSettingsByDataId).toHaveBeenCalledWith('data-id', newSettings);
+        expect(device.homey.setTimeout).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #55

## Summary
- update the mapped VThermo settings immediately from the Homey settings callback
- schedule recalculation only after the complete new settings object is mapped
- preserve and clarify the intentional forced-on behavior when On / off enabled is unchecked

## TDD regression coverage
- switch-off remains accepted when on/off control is enabled
- switch-off is rejected and restored to on when control is disabled
- settings-cache refresh occurs immediately before recalculation

## Verification
- npm test (114 passed, 4 expected failures)
- npm run build
- npm run lint
- Homey app validation passed at publish level

The Homey validator still reports the existing reserved zone_ setting warnings. The timing behavior was exercised through the Homey device callback and API-shaped local registry; it was not tested on physical Homey hardware.