### PR TITLE
Normalize Fahrenheit capability values

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ In Advanced settings, you can choose the types of temperature sensors: standard,
 
 You can use temperature sensors from the same zone, from the parent zone, and from the sub zones.
 
+VThermo supports sensor and physical thermostat capabilities declared in Celsius or Fahrenheit. Calculations use Celsius internally and convert at the Homey API boundary according to each capability's unit metadata, allowing Celsius and Fahrenheit devices to be used together.
+
 #### Triggers
 
 - Turned on

--- a/docs/homey-api-managers.md
+++ b/docs/homey-api-managers.md
@@ -51,6 +51,14 @@ Do not replace the Apps SDK driver lookup with the Web API manager merely becaus
 - **Serialize refresh and event mutations where needed.** A snapshot registration and a concurrent create/update/delete event can otherwise overwrite newer local state or duplicate subscriptions.
 - **Keep API values and metadata intact at the boundary.** Temperature units, `lastUpdated`, availability, readiness, zone, class, virtual class, settings, and capability membership affect selection and control decisions.
 
+### Temperature-unit boundary
+
+VThermo keeps all internal temperature values in Celsius. `DeviceMapper` reads each Web API capability's own `units` metadata and converts `measure_temperature` and `target_temperature` values from Fahrenheit when the capability declares `°F`, `F`, or `Fahrenheit`. Celsius and unknown-unit values pass through unchanged to avoid double conversion.
+
+Capability-instance events use the source unit retained in the internal `DeviceCapability`, so snapshots and live updates follow the same conversion path. Physical `target_temperature` requests are converted from canonical Celsius back to the target capability's declared Fahrenheit unit immediately before `ManagerDevices.setCapabilityValue()`. Pending-write tracking and confirmation remain canonical Celsius, including when Homey confirms the write with a Fahrenheit event value.
+
+Do not apply Homey's global metric/imperial setting as an unconditional conversion rule. A single Homey can contain capabilities with different declared units, and local Apps SDK capability values use the app capability contract rather than this Web API normalization path.
+
 The official manager requires read access for device fetches and control access for capability writes. Those Web API scope names describe API authorization; do not copy them blindly into the Homey app manifest. This app obtains an App API through the Apps SDK and declares `homey:manager:api` in its manifest.
 
 ## ManagerZones

--- a/lib/DeviceMapper.ts
+++ b/lib/DeviceMapper.ts
@@ -6,6 +6,7 @@ import {TemperatureSettingsMapper} from './TemperatureSettingsMapper';
 import {TargetSettingsMapper} from './TargetSettingsMapper';
 import {DeviceSettingsMapper} from './DeviceSettingsMapper';
 import {HumiditySettingsMapper} from './HumiditySettingsMapper';
+import {toCanonicalTemperature} from './TemperatureUnits';
 
 export class DeviceMapper {
     static map(i: HomeyAPIV3Local.ManagerDevices.Device): Device {
@@ -37,7 +38,9 @@ export class DeviceMapper {
         for (const key in caps) {
             if (caps.hasOwnProperty(key) && SUPPORTED_CAPABILITIES.includes(key)) {
                 const values = caps[key];
-                const dc = new DeviceCapability(values['value'], new Date(values['lastUpdated']).getTime());
+                const units = values['units'];
+                const value = toCanonicalTemperature(key, values['value'], units);
+                const dc = new DeviceCapability(value, new Date(values['lastUpdated']).getTime(), units);
                 capabilities.set(key, dc);
             }
         }

--- a/lib/Devices.ts
+++ b/lib/Devices.ts
@@ -13,6 +13,7 @@ import {
 } from './types';
 import {Calculator} from './Calculator';
 import {DeviceMapper} from './DeviceMapper';
+import {fromCanonicalTemperature, toCanonicalTemperature} from './TemperatureUnits';
 
 const PHYSICAL_UPDATE_RETRY_BASE_DELAY = 5000;
 const PHYSICAL_UPDATE_MAX_ATTEMPTS = 3;
@@ -406,9 +407,11 @@ export class Devices {
     ) {
         const deviz = this.getDevice(device.id);
         if (deviz) {
-            this.confirmPhysicalUpdate(device.id, capabilityId, value);
-            if (deviz.hasChangedValue(capabilityId, value)) {
-                deviz.setLocalCapabilityValue(capabilityId, value);
+            const capability = deviz.getLocalCapabilityValue(capabilityId);
+            const canonicalValue = toCanonicalTemperature(capabilityId, value, capability?.units);
+            this.confirmPhysicalUpdate(device.id, capabilityId, canonicalValue);
+            if (deviz.hasChangedValue(capabilityId, canonicalValue)) {
+                deviz.setLocalCapabilityValue(capabilityId, canonicalValue);
                 this.calculator?.startCalculation();
                 this.logger?.debug(
                     `Updated device capability: ${device.id} ${capabilityId} at ${new Date().toISOString()}`,
@@ -474,7 +477,9 @@ export class Devices {
     private async updatePhysicalDevice(dr: DeviceRequest): Promise<void> {
         const pending = this.trackPhysicalUpdate(dr);
         try {
-            await this.homey?.app.setCapabilityValue(dr.id, dr.capabilityId, dr.value);
+            const capability = this.getDevice(dr.id)?.getLocalCapabilityValue(dr.capabilityId);
+            const apiValue = fromCanonicalTemperature(dr.capabilityId, dr.value, capability?.units);
+            await this.homey?.app.setCapabilityValue(dr.id, dr.capabilityId, apiValue);
             if (dr.deviceDelay && dr.deviceDelay > 0) {
                 await this.homey?.app.delay(dr.deviceDelay);
             }

--- a/lib/TemperatureUnits.ts
+++ b/lib/TemperatureUnits.ts
@@ -1,0 +1,27 @@
+const TEMPERATURE_CAPABILITIES = new Set(['measure_temperature', 'target_temperature']);
+const TEMPERATURE_PRECISION = 1_000_000;
+
+const roundTemperature = (value: number): number =>
+    Math.round((value + Number.EPSILON) * TEMPERATURE_PRECISION) / TEMPERATURE_PRECISION;
+
+export function isFahrenheitUnit(units?: unknown): boolean {
+    if (typeof units !== 'string') {
+        return false;
+    }
+    const normalized = units.trim().toLowerCase().replace('°', '');
+    return normalized === 'f' || normalized === 'fahrenheit';
+}
+
+export function toCanonicalTemperature(capabilityId: string, value: any, units?: unknown): any {
+    if (!TEMPERATURE_CAPABILITIES.has(capabilityId) || typeof value !== 'number' || !isFahrenheitUnit(units)) {
+        return value;
+    }
+    return roundTemperature(((value - 32) * 5) / 9);
+}
+
+export function fromCanonicalTemperature(capabilityId: string, value: any, units?: unknown): any {
+    if (!TEMPERATURE_CAPABILITIES.has(capabilityId) || typeof value !== 'number' || !isFahrenheitUnit(units)) {
+        return value;
+    }
+    return roundTemperature((value * 9) / 5 + 32);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,10 +16,12 @@ export enum DeviceClass {
 export class DeviceCapability {
     value: any;
     lastUpdated: number;
+    units?: string | null;
 
-    constructor(value: any, lastUpdated: number) {
+    constructor(value: any, lastUpdated: number, units?: string | null) {
         this.value = value;
         this.lastUpdated = lastUpdated;
+        this.units = units;
     }
 }
 

--- a/tasks/github-issues/59-fahrenheit-capability-values.md
+++ b/tasks/github-issues/59-fahrenheit-capability-values.md
@@ -1,7 +1,7 @@
 # GitHub #59: Fahrenheit capability values are interpreted as Celsius
 
 - Issue: https://github.com/balmli/no.almli.thermostat/issues/59
-- Status: Investigation
+- Status: Completed 2026-07-20
 - Priority: High
 
 ## Report
@@ -16,12 +16,18 @@ On a US Homey configured for Fahrenheit, VThermo averages two sensor values but 
 4. Add paired Celsius/Fahrenheit fixtures covering average, validation bounds, hysteresis, manual update, target propagation, and physical thermostat control.
 5. Keep all internal calculations in one documented canonical unit and convert only at the API boundary if conversion is required.
 
-## Information needed
-
-- Homey model/firmware and VThermo version.
-- Sensor brands/apps/models and their displayed readings.
-- A diagnostic report captured with Fahrenheit enabled.
-
 ## Done when
 
 VThermo displays and controls equivalent physical temperatures correctly under both Celsius and Fahrenheit Homey configurations without double conversion.
+
+## Resolution
+
+- The internal device model now uses Celsius as its documented canonical temperature unit.
+- Web API `measure_temperature` and `target_temperature` snapshots declaring Fahrenheit units are converted to Celsius during device mapping.
+- Live capability events use the retained source-unit metadata and are normalized through the same boundary before comparison, calculation, and write confirmation.
+- Physical thermostat targets are converted from canonical Celsius back to the capability's declared Fahrenheit unit immediately before the Homey API write.
+- Celsius and unknown-unit capability values pass through unchanged, avoiding global-unit assumptions and double conversion.
+- Local VThermo Apps SDK capability values remain on the SDK path and are not treated as Web API Fahrenheit payloads.
+- Regression tests cover Fahrenheit freezing/room/boiling values, mixed-unit averaging, snapshots, live events, Celsius pass-through, unknown units, physical target writes, and Fahrenheit confirmation events. Existing validation, hysteresis, manual-input, target-propagation, and physical-thermostat tests continue to exercise canonical Celsius behavior.
+
+The automated suite uses API-shaped capability fixtures that match the reported Fahrenheit values and `units` metadata. Final display behavior and third-party driver metadata remain unverified on a physical US Homey.

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -144,6 +144,24 @@ describe('Devices registry', () => {
         expect(destroys.every(destroy => destroy.mock.calls.length === 1)).toBe(true);
     });
 
+    it('normalizes Fahrenheit capability events before updating the local model', () => {
+        let listener!: (value: unknown) => void;
+        const api = makeApiDevice({id: 'sensor', capabilities: {measure_temperature: 68}});
+        api.capabilitiesObj.measure_temperature.units = '°F';
+        api.makeCapabilityInstance = vi.fn((_id: string, callback: (value: unknown) => void) => {
+            listener = callback;
+            return {destroy: vi.fn()};
+        });
+        const calculator = {startCalculation: vi.fn()};
+        const devices = new Devices({api} as any);
+        devices.setCalculator(calculator as any);
+
+        listener(77);
+
+        expect(devices.getDevice('sensor')?.getLocalCapabilityValue('measure_temperature').value).toBe(25);
+        expect(calculator.startCalculation).toHaveBeenCalledOnce();
+    });
+
     it('replaces capability subscriptions when an API device is refreshed', () => {
         let firstListener!: (value: unknown) => void;
         let secondListener!: (value: unknown) => void;
@@ -270,6 +288,23 @@ describe('Devices updates to Homey', () => {
         expect(setCapabilityValue.mock.invocationCallOrder[0]).toBeLessThan(delay.mock.invocationCallOrder[0]);
     });
 
+    it('converts canonical Celsius when writing a Fahrenheit physical thermostat target', async () => {
+        const thermostat = makeApiDevice({
+            id: 'thermostat',
+            deviceClass: DeviceClass.thermostat,
+            capabilities: {target_temperature: 68},
+        });
+        thermostat.capabilitiesObj.target_temperature.units = '°F';
+        const setCapabilityValue = vi.fn().mockResolvedValue(undefined);
+        const devices = new Devices({thermostat} as any, {app: {setCapabilityValue}});
+
+        await devices.updateDevices(request({id: 'thermostat', capabilityId: 'target_temperature', value: 21}));
+
+        expect(setCapabilityValue).toHaveBeenCalledOnce();
+        expect(setCapabilityValue.mock.calls[0]).toEqual(['thermostat', 'target_temperature', 69.8]);
+        expect(devices.getDevice('thermostat')?.getLocalCapabilityValue('target_temperature').value).toBe(20);
+    });
+
     it('does not resolve until an undelayed physical update completes', async () => {
         let finishWrite!: () => void;
         const write = new Promise<void>(resolve => {
@@ -349,6 +384,32 @@ describe('Devices updates to Homey', () => {
         expect(devices.getDevice('heater')?.getLocalCapabilityValue('onoff').value).toBe(false);
         expect(startCalculation).toHaveBeenCalledTimes(1);
         expect(startCalculation).toHaveBeenCalledWith();
+    });
+
+    it('confirms a canonical target write from its Fahrenheit capability event', async () => {
+        let capabilityListener!: (value: unknown) => void;
+        const thermostat = makeApiDevice({
+            id: 'thermostat',
+            deviceClass: DeviceClass.thermostat,
+            capabilities: {target_temperature: 68},
+        });
+        thermostat.capabilitiesObj.target_temperature.units = '°F';
+        thermostat.makeCapabilityInstance = vi.fn((_id: string, listener: (value: unknown) => void) => {
+            capabilityListener = listener;
+            return {destroy: vi.fn()};
+        });
+        const setCapabilityValue = vi.fn().mockImplementation(async (_id, _capabilityId, value) => {
+            capabilityListener(value);
+        });
+        const startCalculation = vi.fn();
+        const devices = new Devices({thermostat} as any, {app: {setCapabilityValue}});
+        devices.setCalculator({startCalculation} as any);
+
+        await devices.updateDevices(request({id: 'thermostat', capabilityId: 'target_temperature', value: 21}));
+
+        expect(setCapabilityValue).toHaveBeenCalledWith('thermostat', 'target_temperature', 69.8);
+        expect(devices.getDevice('thermostat')?.getLocalCapabilityValue('target_temperature').value).toBeCloseTo(21);
+        expect(startCalculation).toHaveBeenCalledOnce();
     });
 
     it('logs and continues when a local device or physical write is unavailable', async () => {

--- a/tests/mappers.test.ts
+++ b/tests/mappers.test.ts
@@ -132,6 +132,17 @@ describe('DeviceMapper', () => {
         expect(mapped.capabilitiesObj?.has('unsupported_capability')).toBe(false);
     });
 
+    it('normalizes Fahrenheit temperature capabilities to canonical Celsius', () => {
+        const apiDevice = makeApiDevice({capabilities: {measure_temperature: 68, target_temperature: 77}});
+        apiDevice.capabilitiesObj.measure_temperature.units = '°F';
+        apiDevice.capabilitiesObj.target_temperature.units = '°F';
+
+        const mapped = DeviceMapper.map(apiDevice);
+
+        expect(mapped.capabilitiesObj?.get('measure_temperature')).toMatchObject({value: 20, units: '°F'});
+        expect(mapped.capabilitiesObj?.get('target_temperature')).toMatchObject({value: 25, units: '°F'});
+    });
+
     it('attaches all applicable virtual thermostat settings', () => {
         const apiDevice = makeApiDevice({driverId: DRIVER_VTHERMO, capabilities: {target_temperature: 20}});
         apiDevice.settings = {calc_method: CalcMethod.MANUAL, devices_zone_heaters: true};

--- a/tests/temperature-units.test.ts
+++ b/tests/temperature-units.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest';
+import {fromCanonicalTemperature, isFahrenheitUnit, toCanonicalTemperature} from '../lib/TemperatureUnits';
+
+describe('temperature unit boundary', () => {
+    it.each([
+        [-40, -40],
+        [32, 0],
+        [68, 20],
+        [77, 25],
+        [212, 100],
+    ])('converts %s °F API values to %s °C internally', (fahrenheit, celsius) => {
+        expect(toCanonicalTemperature('measure_temperature', fahrenheit, '°F')).toBeCloseTo(celsius);
+    });
+
+    it.each([
+        [-40, -40],
+        [0, 32],
+        [20, 68],
+        [25, 77],
+        [100, 212],
+    ])('converts %s °C internally to %s °F for API writes', (celsius, fahrenheit) => {
+        expect(fromCanonicalTemperature('target_temperature', celsius, '°F')).toBeCloseTo(fahrenheit);
+    });
+
+    it('recognizes common Fahrenheit unit labels', () => {
+        expect(isFahrenheitUnit('°F')).toBe(true);
+        expect(isFahrenheitUnit('f')).toBe(true);
+        expect(isFahrenheitUnit('Fahrenheit')).toBe(true);
+        expect(isFahrenheitUnit('°C')).toBe(false);
+    });
+
+    it('leaves Celsius, unknown units, non-temperature capabilities and null values unchanged', () => {
+        expect(toCanonicalTemperature('measure_temperature', 20, '°C')).toBe(20);
+        expect(toCanonicalTemperature('measure_temperature', 20)).toBe(20);
+        expect(toCanonicalTemperature('measure_humidity', 68, '°F')).toBe(68);
+        expect(toCanonicalTemperature('measure_temperature', null, '°F')).toBeNull();
+        expect(fromCanonicalTemperature('onoff', true, '°F')).toBe(true);
+    });
+
+    it.each([0.25, 0.5, 1, 20.5, 22.25])('round-trips %s °C without floating-point residue', celsius => {
+        const fahrenheit = fromCanonicalTemperature('target_temperature', celsius, '°F');
+        expect(toCanonicalTemperature('target_temperature', fahrenheit, '°F')).toBe(celsius);
+    });
+});

--- a/tests/vthermo-calculator.test.ts
+++ b/tests/vthermo-calculator.test.ts
@@ -1,8 +1,9 @@
 import {describe, expect, it, vi} from 'vitest';
 import {VThermoDeviceCalculator} from '../lib/VThermoDeviceCalculator';
+import {DeviceMapper} from '../lib/DeviceMapper';
 import {Zones} from '../lib/Zones';
 import {CalcMethod, CAPABILITY_ACTIVE, DeviceCapability, DeviceClass, TemperatureSettingsZone} from '../lib/types';
-import {makeDevice, makeDevicesStub, makeVThermo, makeZone, NOW} from './helpers';
+import {makeApiDevice, makeDevice, makeDevicesStub, makeVThermo, makeZone, NOW} from './helpers';
 
 describe('VThermoDeviceCalculator temperature inputs', () => {
     it('selects enabled sensor categories and excludes the controlling virtual thermostat', () => {
@@ -99,6 +100,24 @@ describe('VThermoDeviceCalculator temperature inputs', () => {
             capabilityId: 'measure_temperature',
             value: 20,
         });
+    });
+
+    it('averages equivalent Celsius and Fahrenheit API readings in Celsius', () => {
+        const celsius = DeviceMapper.map(makeApiDevice({id: 'celsius', capabilities: {measure_temperature: 20}}));
+        const fahrenheitApi = makeApiDevice({id: 'fahrenheit', capabilities: {measure_temperature: 77}});
+        fahrenheitApi.capabilitiesObj.measure_temperature.units = '°F';
+        const fahrenheit = DeviceMapper.map(fahrenheitApi);
+        const device = makeVThermo({
+            capabilities: {measure_temperature: 0},
+            temperatureSettings: {calcMethod: CalcMethod.AVERAGE, zone: {sensor: true}},
+        });
+
+        expect(
+            new VThermoDeviceCalculator(
+                new Zones(),
+                makeDevicesStub([celsius, fahrenheit]),
+            ).calculateMeasureTemperature(device, makeZone('root')),
+        ).toMatchObject({value: 22.5});
     });
 
     it('returns null when no automatic reading is available', () => {


### PR DESCRIPTION
Closes #59

## Summary
- keep all internal temperature calculations in canonical Celsius
- normalize Fahrenheit measure_temperature and target_temperature snapshots and live events using each capability's units metadata
- convert canonical Celsius back to Fahrenheit only when writing a physical Fahrenheit thermostat target
- keep pending-write tracking and confirmation in Celsius
- leave Celsius, unknown-unit, non-temperature, and local Apps SDK values unchanged
- document the Homey API unit boundary

No expected-failure task is directly related to this issue.

## TDD regression coverage
- Fahrenheit freezing, room, and boiling conversions
- exact Celsius/Fahrenheit round trips without floating-point confirmation residue
- mixed Celsius/Fahrenheit sensor averaging
- Fahrenheit snapshot and capability-event normalization
- physical Fahrenheit target writes and confirmation events
- Celsius, unknown-unit, non-temperature, and null pass-through
- existing validation, hysteresis, manual input, target propagation, and physical thermostat behavior remain covered in canonical Celsius

## Verification
- npm test: 138 passed, 4 expected failures
- npm run test:coverage: 93.24% statements, 81.96% branches
- npm run build
- npm run lint
- Homey app validation passed at publish level

The Homey validator still reports the existing reserved zone_ setting warnings. The suite uses API-shaped capability fixtures matching the reported Fahrenheit values and units metadata; final display behavior and third-party driver metadata have not been verified on physical US Homey hardware.