### PR TITLE
Document issue 51 as a configuration error

### DIFF
--- a/tasks/github-issues/51-temperature-sensor-discovery.md
+++ b/tasks/github-issues/51-temperature-sensor-discovery.md
@@ -1,7 +1,7 @@
 # GitHub #51: Temperature sensor discovery on Homey Pro 2023
 
 - Issue: https://github.com/balmli/no.almli.thermostat/issues/51
-- Status: Investigation
+- Status: Closed as configuration/user error 2026-07-20
 - Priority: Normal
 
 ## Report
@@ -16,13 +16,14 @@ VThermo on Homey Pro 2023 did not find a temperature sensor after the 1.10.4 Hom
 4. Check whether `homey-api` reports a different class, virtual class, zone, readiness, availability, or capability shape for the affected sensor.
 5. Add a regression fixture matching the diagnostic data if the reporter can provide it.
 
-## Information needed
-
-- Current Homey firmware and VThermo app version.
-- Sensor brand, app, model, class, and zone.
-- Relevant VThermo sensor-selection settings.
-- A diagnostic report captured while the sensor is missing.
-
 ## Done when
 
 The sensor is either discovered correctly with a regression test, or the unsupported device/integration constraint is documented with a practical configuration path.
+
+## Resolution
+
+Closed without a code change. The report is most consistent with VThermo not having an eligible temperature sensor in its configured zone scope rather than a Homey Pro 2023 discovery defect.
+
+The intended sensor and VThermo should be placed in the same Homey zone, with “standard temperature sensors in the same zone” enabled in VThermo Advanced Settings. If Homey exposes the device as a thermostat or another device class, the matching thermostat or “other devices with a temperature capability” category must be enabled instead. Parent- or child-zone sensors require their corresponding zone-scope setting.
+
+No production behavior changed, so no new regression test is required for this configuration resolution.


### PR DESCRIPTION
Closes #51

## Summary
- record that the missing temperature sensor is most likely a zone/sensor-category configuration issue
- document same-zone placement and the matching standard sensor, thermostat, or other-device category
- clarify that parent and child sensors require their corresponding zone-scope settings

No production behavior changed, so no new regression test was required. Prettier formatting validation passed.