### PR TITLE
Avoid duplicate multi-zone sensor readings

### DIFF
--- a/lib/VHumidityDeviceCalculator.ts
+++ b/lib/VHumidityDeviceCalculator.ts
@@ -36,16 +36,14 @@ export class VHumidityDeviceCalculator extends DeviceCalculator {
         const dcs: DeviceCapability[] = [];
         if (zone) {
             const zones = Array.isArray(zone) ? zone : [zone];
-            for (const z of zones) {
-                const devices = this.devicesObj.getDevicesFromZones(zones);
-                const humidities = devices
-                    ?.filter(d => d.class === 'sensor')
-                    .filter(d => d.capabilitiesObj && d.capabilitiesObj.has('measure_humidity'))
-                    .map(d => d.capabilitiesObj && d.capabilitiesObj?.get('measure_humidity'));
-                if (humidities) {
-                    // @ts-ignore
-                    dcs.push(...humidities);
-                }
+            const devices = this.devicesObj.getDevicesFromZones(zones);
+            const humidities = devices
+                ?.filter(d => d.class === 'sensor')
+                .filter(d => d.capabilitiesObj && d.capabilitiesObj.has('measure_humidity'))
+                .map(d => d.capabilitiesObj && d.capabilitiesObj?.get('measure_humidity'));
+            if (humidities) {
+                // @ts-ignore
+                dcs.push(...humidities);
             }
         }
         return dcs;

--- a/lib/VThermoDeviceCalculator.ts
+++ b/lib/VThermoDeviceCalculator.ts
@@ -39,22 +39,20 @@ export class VThermoDeviceCalculator extends DeviceCalculator {
         const dcs: DeviceCapability[] = [];
         if (zone && tempSettings) {
             const zones = Array.isArray(zone) ? zone : [zone];
-            for (const z of zones) {
-                const devices = this.devicesObj.getDevicesFromZones(zones);
-                const temperatures = devices
-                    ?.filter(
-                        d =>
-                            (tempSettings.sensor && d.class === 'sensor') ||
-                            (tempSettings.thermostat && d.class === 'thermostat' && !d.isVThermo()) ||
-                            (tempSettings.vthermo && d.isVThermo()) ||
-                            (tempSettings.other && d.class !== 'sensor' && d.class !== 'thermostat'),
-                    )
-                    .filter(d => d.capabilitiesObj && d.capabilitiesObj.has('measure_temperature'))
-                    .map(d => d.capabilitiesObj && d.capabilitiesObj?.get('measure_temperature'));
-                if (temperatures) {
-                    // @ts-ignore
-                    dcs.push(...temperatures);
-                }
+            const devices = this.devicesObj.getDevicesFromZones(zones);
+            const temperatures = devices
+                ?.filter(
+                    d =>
+                        (tempSettings.sensor && d.class === 'sensor') ||
+                        (tempSettings.thermostat && d.class === 'thermostat' && !d.isVThermo()) ||
+                        (tempSettings.vthermo && d.isVThermo()) ||
+                        (tempSettings.other && d.class !== 'sensor' && d.class !== 'thermostat'),
+                )
+                .filter(d => d.capabilitiesObj && d.capabilitiesObj.has('measure_temperature'))
+                .map(d => d.capabilitiesObj && d.capabilitiesObj?.get('measure_temperature'));
+            if (temperatures) {
+                // @ts-ignore
+                dcs.push(...temperatures);
             }
         }
         return dcs;

--- a/tasks/expected-failures/03-duplicate-temperature-readings.md
+++ b/tasks/expected-failures/03-duplicate-temperature-readings.md
@@ -1,5 +1,7 @@
 # Stop duplicating multi-zone temperature readings
 
+- Status: Completed 2026-07-20
+
 ## Problem
 
 `VThermoDeviceCalculator.getTemperaturesInZone()` loops over each requested zone but fetches devices from the complete zone array during every iteration. With two zones, every selected reading is returned twice; with three zones, every reading is returned three times.
@@ -26,3 +28,7 @@ Either fetch from the complete zone array once without a loop, or fetch from the
 - Category filtering remains unchanged.
 - Change the related test from `it.fails` to `it`.
 - `npm test`, `npm run test:coverage`, `npm run lint`, and `npm run build` pass.
+
+## Resolution
+
+`getTemperaturesInZone()` now queries the complete supplied zone scope once, then applies the existing sensor-category and capability filters. Each matching temperature capability therefore contributes once regardless of the number of selected zones. The former `it.fails` case is a normal regression test and also covers empty and undefined zone scopes.

--- a/tasks/expected-failures/04-duplicate-humidity-readings.md
+++ b/tasks/expected-failures/04-duplicate-humidity-readings.md
@@ -1,5 +1,7 @@
 # Stop duplicating multi-zone humidity readings
 
+- Status: Completed 2026-07-20
+
 ## Problem
 
 `VHumidityDeviceCalculator.getHumiditiesInZone()` loops over every requested zone while querying the entire zone array in each iteration. Every selected humidity reading is consequently duplicated once per zone.
@@ -24,3 +26,7 @@ Query the complete zone array once, or use the current loop zone for each iterat
 - Empty and undefined scopes still return an empty array.
 - Change the related test from `it.fails` to `it`.
 - `npm test`, `npm run test:coverage`, `npm run lint`, and `npm run build` pass.
+
+## Resolution
+
+`getHumiditiesInZone()` now queries the complete supplied zone scope once, then applies the existing sensor-class and `measure_humidity` filters. Each matching humidity capability therefore contributes once regardless of the number of selected zones. The former `it.fails` case is a normal regression test and also covers empty and undefined zone scopes.

--- a/tests/vhumidity-calculator.test.ts
+++ b/tests/vhumidity-calculator.test.ts
@@ -18,7 +18,7 @@ describe('VHumidityDeviceCalculator measurements', () => {
         expect(calculator.getHumiditiesInZone(root).map(value => value.value)).toEqual([40]);
     });
 
-    it.fails('does not duplicate readings when several zones are selected', () => {
+    it('does not duplicate readings when several zones are selected', () => {
         const zones = [makeZone('one'), makeZone('two')];
         const calculator = new VHumidityDeviceCalculator(
             new Zones(),
@@ -28,6 +28,8 @@ describe('VHumidityDeviceCalculator measurements', () => {
             ]),
         );
         expect(calculator.getHumiditiesInZone(zones).map(value => value.value)).toEqual([40, 60]);
+        expect(calculator.getHumiditiesInZone([])).toEqual([]);
+        expect(calculator.getHumiditiesInZone(undefined)).toEqual([]);
     });
 
     it.each([

--- a/tests/vthermo-calculator.test.ts
+++ b/tests/vthermo-calculator.test.ts
@@ -29,7 +29,7 @@ describe('VThermoDeviceCalculator temperature inputs', () => {
         expect(calculator.getTemperaturesInZone(root, settings).map(value => value.value)).toEqual([10, 20, 40]);
     });
 
-    it.fails('does not duplicate readings when several zones are selected', () => {
+    it('does not duplicate readings when several zones are selected', () => {
         const zones = [makeZone('one'), makeZone('two')];
         const calculator = new VThermoDeviceCalculator(
             new Zones(),
@@ -39,6 +39,8 @@ describe('VThermoDeviceCalculator temperature inputs', () => {
             ]),
         );
         expect(calculator.getTemperaturesInZone(zones, {sensor: true}).map(value => value.value)).toEqual([10, 20]);
+        expect(calculator.getTemperaturesInZone([], {sensor: true})).toEqual([]);
+        expect(calculator.getTemperaturesInZone(undefined, {sensor: true})).toEqual([]);
     });
 
     it('combines current, parent and direct-child sensor scopes', () => {


### PR DESCRIPTION
## Summary

- query selected zones once when collecting temperature readings
- query selected zones once when collecting humidity readings
- convert both duplicate-reading expected failures into regression tests
- document both expected failures as resolved

## TDD

Each fix was developed independently with a failing regression test first, followed by the smallest implementation change. The changes are split into two atomic commits: one for temperature readings and one for humidity readings.

## Verification

- `npm test`: 140 passed, 2 expected failures
- `npm run test:coverage`: 93.22% statements, 82.12% branches, 96.19% functions, 93.07% lines
- `npm run build`
- `npm run lint`

This PR resolves the local expected-failure tasks `03-duplicate-temperature-readings.md` and `04-duplicate-humidity-readings.md`. It does not close a GitHub issue.