### PR TITLE
Fix invalid logger-level error reporting

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -47,10 +47,10 @@ class Logger {
             this.logLevel = logLevelMap.get(logLevel);
         } else {
             throw new Error(
-                `Unsupported loglevel (${logLevel}) given. Please choose from ${logLevelMap
-                    .entries()
-                    .map(entry => entry.join(':'))
-                    .join(', ')}`,
+                `Unsupported loglevel (${logLevel}) given. Please choose from ${Array.from(
+                    logLevelMap.entries(),
+                    entry => entry.join(':'),
+                ).join(', ')}`,
             );
         }
         return this.logLevel;

--- a/tasks/expected-failures/08-invalid-logger-level-message.md
+++ b/tasks/expected-failures/08-invalid-logger-level-message.md
@@ -1,5 +1,7 @@
 # Fix invalid logger-level error reporting
 
+Status: Completed 2026-07-20
+
 ## Problem
 
 When `Logger.setLogLevel()` receives an unsupported value, it tries to call `.map()` directly on the iterator returned by `logLevelMap.entries()`. Iterators do not provide `.map()`, so the method throws an unrelated `TypeError` while constructing the intended validation error.
@@ -24,3 +26,7 @@ Convert the entries iterator to an array before mapping, or construct the list w
 - Named and numeric valid levels continue to work.
 - Change the related test from `it.fails` to `it`.
 - `npm test`, `npm run test:coverage`, `npm run lint`, and `npm run build` pass.
+
+## Resolution
+
+`Logger.setLogLevel()` now converts the supported-level entries iterator to an array while formatting the validation message. Invalid values therefore throw the intended explanatory `Error`, including all six supported names and numeric ids. The expected-failure test is now a passing regression test that verifies the complete message.

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -36,7 +36,12 @@ describe('Logger', () => {
         expect(log).toHaveBeenCalledWith('[Info]', 'message');
     });
 
-    it.fails('reports supported values when an invalid log level is provided', () => {
-        expect(() => new Logger({logLevel: 'invalid'})).toThrow(/Unsupported loglevel.*silly:1/);
+    it('reports supported values when an invalid log level is provided', () => {
+        expect(() => new Logger({logLevel: 'invalid'})).toThrow(
+            new Error(
+                'Unsupported loglevel (invalid) given. Please choose from ' +
+                    'silly:1, debug:2, verbose:3, info:4, warn:5, error:6',
+            ),
+        );
     });
 });


### PR DESCRIPTION
## Summary

- convert the supported log-level entries iterator while formatting validation errors
- report all six supported named and numeric logger levels for invalid input
- convert the expected failure into a regression test for the complete message
- mark expected-failure task 08 as completed

## TDD

The existing expected-failure test was first converted into a stricter normal test. It reproduced the iterator `.map()` `TypeError`, after which the minimal production fix was applied.

## Verification

- `npm test`: 141 passed, 1 unrelated expected failure
- `npm run test:coverage`: 93.34% statements, 82.12% branches, 96.73% functions, 93.19% lines
- `npm run lint`
- `npm run build`
- Homey app validation: publish level passed with existing reserved-setting warnings

This PR resolves `tasks/expected-failures/08-invalid-logger-level-message.md`.