### PR TITLE
Preserve zero-valued humidity history

### DIFF
--- a/lib/ValueStore.ts
+++ b/lib/ValueStore.ts
@@ -43,6 +43,6 @@ export class ValueStore {
         const ts = now - minutes * 60000;
         const newest = this.sameAgeOrOlderThan(now);
         const newestOlderThan = this.sameAgeOrOlderThan(ts);
-        return newest && newestOlderThan ? newest - newestOlderThan : undefined;
+        return newest !== undefined && newestOlderThan !== undefined ? newest - newestOlderThan : undefined;
     }
 }

--- a/tasks/expected-failures/02-zero-humidity-history.md
+++ b/tasks/expected-failures/02-zero-humidity-history.md
@@ -1,5 +1,7 @@
 # Preserve zero-valued humidity history
 
+Status: Completed 2026-07-20
+
 ## Problem
 
 `ValueStore.changePctPointsLastMinutes()` uses truthiness to decide whether current and historical values exist. A valid reading of `0` is therefore treated as missing, and the method returns `undefined` instead of the percentage-point change.
@@ -24,3 +26,7 @@ Replace truthiness checks with explicit `undefined` checks. Preserve positive an
 - Missing current or historical readings still return `undefined`.
 - Change the related test from `it.fails` to `it` and add the reverse zero case.
 - `npm test`, `npm run test:coverage`, `npm run lint`, and `npm run build` pass.
+
+## Resolution
+
+`ValueStore.changePctPointsLastMinutes()` now checks explicitly for `undefined`, preserving zero as a valid current or historical value. Regression coverage verifies changes from `0` to `5`, changes from `5` to `0`, and genuinely missing readings.

--- a/tests/value-store.test.ts
+++ b/tests/value-store.test.ts
@@ -39,14 +39,20 @@ describe('ValueStore', () => {
 
     it('returns undefined when the requested historical reading is unavailable', () => {
         const store = new ValueStore();
+        expect(store.changePctPointsLastMinutes(10, NOW)).toBeUndefined();
         store.addValue(47, NOW);
         expect(store.changePctPointsLastMinutes(10, NOW)).toBeUndefined();
     });
 
-    it.fails('supports legitimate zero-valued humidity readings', () => {
-        const store = new ValueStore();
-        store.addValue(0, NOW - 5 * 60_000);
-        store.addValue(5, NOW);
-        expect(store.changePctPointsLastMinutes(5, NOW)).toBe(5);
+    it('supports legitimate zero-valued humidity readings', () => {
+        const increase = new ValueStore();
+        increase.addValue(0, NOW - 5 * 60_000);
+        increase.addValue(5, NOW);
+        expect(increase.changePctPointsLastMinutes(5, NOW)).toBe(5);
+
+        const decrease = new ValueStore();
+        decrease.addValue(5, NOW - 5 * 60_000);
+        decrease.addValue(0, NOW);
+        expect(decrease.changePctPointsLastMinutes(5, NOW)).toBe(-5);
     });
 });


### PR DESCRIPTION
## Summary

- distinguish missing humidity history from legitimate zero values
- preserve percentage-point changes from `0` to `5` and from `5` to `0`
- retain `undefined` when current or historical readings are genuinely absent
- convert expected failure 02 into passing regression coverage and mark the task completed

## TDD

The expected-failure test was first converted to a normal test and expanded with the reverse-zero and empty-history cases. It failed because a stored zero was treated as false. The production change then replaced the truthiness condition with explicit `undefined` checks.

## Verification

- `npm test`: 142 passed, no expected failures
- `npm run test:coverage`: 93.34% statements, 82.12% branches, 96.73% functions, 93.19% lines
- `npm run lint`
- `npm run build`
- Homey app validation: publish level passed with existing reserved-setting warnings

This PR resolves `tasks/expected-failures/02-zero-humidity-history.md`.