### PR TITLE
Release 1.11.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,4 +1,7 @@
 {
+  "1.11.0": {
+    "en": "Reliability improvements for sensor updates, calculations, device control, Fahrenheit temperatures, multi-zone readings, and zero-valued settings and history."
+  },
   "1.10.4": {
     "en": "Fixes for Homey Pro 2023."
   },

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "no.almli.thermostat",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "compatibility": ">=8.1.2",
   "sdk": 3,
   "brandColor": "#df20cb",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,16 @@ Homey hardware/API behavior cannot be established by compilation alone. For inte
 - When completing a task in `tasks/github-issues/`, comment on the linked GitHub issue with a concise summary of the fix, its tests, and any relevant release status. Keep the comment polite, appreciative, and helpful.
 - Do not ask issue reporters or other users for more information, logs, diagnostics, reproduction details, or follow-up work. Base issue comments and implementation decisions on the available report, repository evidence, and tests.
 
+## Release workflow
+
+- Prepare a release only when the user explicitly requests a version. Start from an up-to-date default branch and create a dedicated `release/<version>` branch.
+- Treat `.homeycompose/app.json` as the source of truth for the Homey app version. Update its `version`, add the new version first in `.homeychangelog.json`, and add a matching newest-first section under `README.md` → Release Notes.
+- Write release notes for users: summarize observable fixes, compatibility changes, and safety-relevant behavior without exposing implementation-only details or claiming unverified hardware behavior.
+- Run `npm run format`, then `npm run build`, `npm test`, and `npm run lint`. The test postscript runs Homey publish-level validation and regenerates the tracked root `app.json`; inspect that generated diff and keep its version synchronized with the compose source.
+- Review the complete diff for unintended generated-manifest changes, then create one atomic release commit, push the release branch, and open a pull request targeting the default branch.
+- Do not create a tag, GitHub release, publish to Homey, or change the package version unless the user explicitly requests that action.
+- When a release is intended to gather real-world testing for open GitHub issues, add a polite comment describing the relevant improvements and release status. Do not claim the issue is fixed, close it prematurely, or request logs or diagnostics.
+
 ## Change discipline
 
 - Preserve backward compatibility for paired devices, saved settings, capability IDs, and Flow cards.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ Please report issues at the [issues section on Github](https://github.com/balmli
 
 ## Release Notes:
 
+#### 1.11.0
+
+- Improved Homey device subscription refresh and API lifecycle cleanup
+- Added bounded recovery for transient calculation failures
+- Await, confirm, and retry physical device updates without assuming unconfirmed state
+- Preserve heater outputs when temperature input is temporarily unavailable
+- Added correct Celsius/Fahrenheit conversion at the Homey API boundary
+- Fixed duplicate temperature and humidity readings when using multiple zones
+- Added support for zero hysteresis and zero target-temperature limits
+- Fixed stale-measurement fallback and maximum-age handling
+- Fixed VThermo reactivation after enabling on/off control
+- Fixed zero-valued humidity history and invalid logger-level errors
+
 #### 1.10.4
 
 - Fixes for Homey Pro 2023

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "no.almli.thermostat",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "compatibility": ">=8.1.2",
   "sdk": 3,
   "brandColor": "#df20cb",


### PR DESCRIPTION
## Summary

- bump the Homey app version from 1.10.4 to 1.11.0
- add Homey and README release notes for the accumulated reliability fixes
- regenerate the tracked app manifest from `.homeycompose/app.json`
- document the release procedure in `AGENTS.md`

## Verification

- `npm run build`
- `npm test`: 142 passed
- `npm run lint`
- Homey app validation: publish level passed with the existing reserved-setting warnings

## User testing

Polite notices were added to open issues #50, #61, and #62. Those issues remain open while users have an opportunity to test version 1.11.0.

This PR prepares the release metadata only. It does not tag, publish, or create a GitHub release.