### PR TITLE
Turn controlled heaters off with VThermo switch

### DIFF
--- a/drivers/VThermo/device.ts
+++ b/drivers/VThermo/device.ts
@@ -22,6 +22,10 @@ module.exports = class VThermoDevice extends BaseDevice {
                 }
                 throw new Error(this.homey.__('error.switching_disabled'));
             }
+            // Keep the Web API-backed model in sync immediately so switching off
+            // cannot depend on a later capability subscription event.
+            // @ts-ignore
+            this.homey.app.updateByDataId(this.getData().id, 'onoff', value);
         });
         this.registerCapabilityListener('target_temperature', async (value: any, opts: any) => {
             // @ts-ignore

--- a/lib/VThermoDeviceCalculator.ts
+++ b/lib/VThermoDeviceCalculator.ts
@@ -267,6 +267,12 @@ export class VThermoDeviceCalculator extends DeviceCalculator {
             return requests;
         }
 
+        const mainOnoff = device.getLocalCapabilityValue('onoff');
+        if (deviceSettings.onoffEnabled && mainOnoff?.value === false) {
+            this.addSwitchingRequests(device, zone, deviceSettings, requests, false);
+            return requests;
+        }
+
         const targetTemperature = device.getLocalCapabilityValue('target_temperature');
         if (!targetTemperature || targetTemperature.value === undefined || targetTemperature.value === null) {
             return requests;
@@ -283,17 +289,27 @@ export class VThermoDeviceCalculator extends DeviceCalculator {
         const onoff = this.resolveOnOff(device, temperature.value, targetTemperature.value, contactAlarm, motionAlarm);
 
         if (onoff !== undefined) {
-            const dr = this.updateAndCreateDeviceRequestIfChanged(device, CAPABILITY_ACTIVE, onoff);
-            if (dr) {
-                dr.trigger = `vt_onoff_${dr.value ? 'true' : 'false'}`;
-            }
-            requests.addRequest(dr);
-
-            this.heatersDeviceRequests(onoff, zone, deviceSettings, requests);
-            this.thermostatsDeviceRequests(onoff, zone, deviceSettings, requests);
+            this.addSwitchingRequests(device, zone, deviceSettings, requests, onoff);
         }
 
         return requests;
+    }
+
+    private addSwitchingRequests(
+        device: Device,
+        zone: Zone,
+        deviceSettings: DeviceSettings,
+        requests: DeviceRequests,
+        onoff: boolean,
+    ): void {
+        const dr = this.updateAndCreateDeviceRequestIfChanged(device, CAPABILITY_ACTIVE, onoff);
+        if (dr) {
+            dr.trigger = `vt_onoff_${dr.value ? 'true' : 'false'}`;
+        }
+        requests.addRequest(dr);
+
+        this.heatersDeviceRequests(onoff, zone, deviceSettings, requests);
+        this.thermostatsDeviceRequests(onoff, zone, deviceSettings, requests);
     }
 
     /**

--- a/tests/vthermo-calculator.test.ts
+++ b/tests/vthermo-calculator.test.ts
@@ -251,6 +251,24 @@ describe('VThermoDeviceCalculator switching', () => {
         expect(calculator().calculateHeaterSwitching(noMeasurement, root).getRequests()).toEqual([]);
     });
 
+    it('turns controlled heaters off when VThermo is switched off without a usable temperature', () => {
+        const root = makeZone('root');
+        const vthermo = makeVThermo({
+            capabilities: {
+                onoff: false,
+                [CAPABILITY_ACTIVE]: false,
+                target_temperature: null,
+                measure_temperature: null,
+            },
+        });
+        const heater = makeDevice({id: 'heater', deviceClass: DeviceClass.heater, capabilities: {onoff: true}});
+        const requests = new VThermoDeviceCalculator(new Zones(), makeDevicesStub([vthermo, heater]))
+            .calculateHeaterSwitching(vthermo, root)
+            .getRequests();
+
+        expect(requests).toEqual([expect.objectContaining({id: 'heater', capabilityId: 'onoff', value: false})]);
+    });
+
     it('selects heaters and thermostats from independently enabled zone scopes', () => {
         const child = makeZone('child', 'root');
         const root = makeZone('root', undefined, [child]);

--- a/tests/vthermo-device.test.ts
+++ b/tests/vthermo-device.test.ts
@@ -5,12 +5,13 @@ const VThermoDevice = (VThermoDeviceModule as any).default ?? VThermoDeviceModul
 
 function makeDevice({onoffEnabled, onoff}: {onoffEnabled: boolean; onoff: boolean}) {
     const listeners = new Map<string, (value: unknown, opts: unknown) => Promise<void>>();
+    const updateByDataId = vi.fn();
     const updateSettingsByDataId = vi.fn();
     const setCapabilityValue = vi.fn().mockResolvedValue(undefined);
     const device = Object.assign(Object.create(VThermoDevice.prototype), {
         homey: {
             __: vi.fn().mockReturnValue('Switching disabled'),
-            app: {updateByDataId: vi.fn(), updateSettingsByDataId},
+            app: {updateByDataId, updateSettingsByDataId},
             setTimeout: vi.fn(),
         },
         logger: {error: vi.fn(), info: vi.fn()},
@@ -22,16 +23,20 @@ function makeDevice({onoffEnabled, onoff}: {onoffEnabled: boolean; onoff: boolea
         setCapabilityOptions: vi.fn().mockResolvedValue(undefined),
         registerCapabilityListener: vi.fn((capabilityId, listener) => listeners.set(capabilityId, listener)),
     });
-    return {device, listeners, setCapabilityValue, updateSettingsByDataId};
+    return {device, listeners, setCapabilityValue, updateByDataId, updateSettingsByDataId};
 }
 
 describe('VThermo Homey device', () => {
     it('keeps switch-off stable when on/off control is enabled', async () => {
-        const {device, listeners, setCapabilityValue} = makeDevice({onoffEnabled: true, onoff: true});
+        const {device, listeners, setCapabilityValue, updateByDataId} = makeDevice({
+            onoffEnabled: true,
+            onoff: true,
+        });
         await device.initialize();
 
         await expect(listeners.get('onoff')!(false, {})).resolves.toBeUndefined();
         expect(setCapabilityValue).not.toHaveBeenCalled();
+        expect(updateByDataId).toHaveBeenCalledWith('data-id', 'onoff', false);
     });
 
     it('restores on and rejects switch-off when on/off control is disabled', async () => {


### PR DESCRIPTION
## Summary

- synchronize enabled VThermo on/off capability changes with the mapped device immediately
- prioritize an explicit VThermo switch-off before temperature/target validation
- continue sending the desired off state when VThermo is already idle but a controlled heater is still on
- preserve the existing non-intrusive behavior for missing temperature input while VThermo remains enabled

## TDD

Regression tests were added first for the Homey on/off listener and for an active controlled heater when VThermo is off, idle, and has no usable temperature. Both tests failed before the implementation change and pass afterward.

## Verification

- `npm run build`
- `npm run lint`
- `npm test`: 143 passed
- Homey app validation: publish level passed with the existing reserved-setting warnings

The app remains at version 1.11.0. This PR does not modify version or release metadata.