### PR TITLE
fix: preserve latest physical output command

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Please report issues at the [issues section on Github](https://github.com/balmli
 
 - Improved Homey device subscription refresh and API lifecycle cleanup
 - Added bounded recovery for transient calculation failures
-- Await, confirm, and retry physical device updates without assuming unconfirmed state
+- Await physical device updates and preserve the latest command while confirmation is pending
 - Preserve heater outputs when temperature input is temporarily unavailable
 - Added correct Celsius/Fahrenheit conversion at the Homey API boundary
 - Fixed duplicate temperature and humidity readings when using multiple zones

--- a/lib/DeviceCalculator.ts
+++ b/lib/DeviceCalculator.ts
@@ -25,11 +25,15 @@ export class DeviceCalculator {
      * @param value
      */
     updateAndCreateDeviceRequestIfChanged(device: Device, capabilityId: string, value: any): DeviceRequest | undefined {
-        if (device.hasChangedValue(capabilityId, value)) {
+        const virtualDevice = device.driverId === DRIVER_VTHERMO || device.driverId === DRIVER_VHUMIDITY;
+        const updateRequired = virtualDevice
+            ? device.hasChangedValue(capabilityId, value)
+            : this.devicesObj.isPhysicalUpdateRequired(device, capabilityId, value);
+        if (updateRequired) {
             //this.logger?.info('DeviceCalculator: updated ', `DeviceCalculator: updated ${device.id} ${device.name} ${capabilityId} = ${value}`);
             const dr = new DeviceRequest();
             dr.id = device.id;
-            if (device.driverId === DRIVER_VTHERMO || device.driverId === DRIVER_VHUMIDITY) {
+            if (virtualDevice) {
                 dr.dataId = device.dataId;
                 device.setLocalCapabilityValue(capabilityId, value);
             }

--- a/lib/Devices.ts
+++ b/lib/Devices.ts
@@ -15,12 +15,8 @@ import {Calculator} from './Calculator';
 import {DeviceMapper} from './DeviceMapper';
 import {fromCanonicalTemperature, toCanonicalTemperature} from './TemperatureUnits';
 
-const PHYSICAL_UPDATE_RETRY_BASE_DELAY = 5000;
-const PHYSICAL_UPDATE_MAX_ATTEMPTS = 3;
-
 type PendingPhysicalUpdate = {
     value: any;
-    attempts: number;
 };
 
 export class Devices {
@@ -189,6 +185,7 @@ export class Devices {
 
     private updateDeviceData(device: Device, updatedDevice: HomeyAPIV3Local.ManagerDevices.Device): void {
         const newDevice = DeviceMapper.map(updatedDevice);
+        this.confirmPhysicalUpdates(newDevice);
         if (Devices.deviceChanged(device, updatedDevice)) {
             device.name = newDevice.name;
             device.class = newDevice.class;
@@ -314,6 +311,7 @@ export class Devices {
                 const deviceId = device.id;
                 const idx = this.devices.findIndex(d => d.id === deviceId);
                 const deviz = DeviceMapper.map(device);
+                this.confirmPhysicalUpdates(deviz);
                 if (idx >= 0) {
                     this.devices[idx] = deviz;
                 } else {
@@ -438,43 +436,38 @@ export class Devices {
         }
     }
 
+    private confirmPhysicalUpdates(device: Device): void {
+        for (const [capabilityId, capability] of device.capabilitiesObj?.entries() ?? []) {
+            this.confirmPhysicalUpdate(device.id, capabilityId, capability.value);
+        }
+    }
+
+    isPhysicalUpdateRequired(device: Device, capabilityId: string, value: any): boolean {
+        if (!device.hasCapability(capabilityId) || value === undefined) {
+            return false;
+        }
+        const pending = this.pendingPhysicalUpdates.get(capabilityIdFormat(device.id, capabilityId));
+        if (pending) {
+            return pending.value !== value;
+        }
+        return device.hasChangedValue(capabilityId, value);
+    }
+
     private trackPhysicalUpdate(dr: {id: string; capabilityId: string; value?: any}): PendingPhysicalUpdate {
         const key = capabilityIdFormat(dr.id, dr.capabilityId);
         const current = this.pendingPhysicalUpdates.get(key);
-        const pending = {
-            value: dr.value,
-            attempts: current && current.value === dr.value ? current.attempts + 1 : 1,
-        };
+        const pending = {value: dr.value};
         this.pendingPhysicalUpdates.set(key, pending);
+        if (current && current.value !== pending.value) {
+            this.logger?.verbose(
+                `Physical update superseded: ${dr.id}:${dr.capabilityId} ${current.value} -> ${pending.value}`,
+            );
+        }
         return pending;
     }
 
-    private schedulePhysicalUpdateReconciliation(dr: DeviceRequest, pending: PendingPhysicalUpdate): void {
-        const key = capabilityIdFormat(dr.id, dr.capabilityId);
-        const current = this.pendingPhysicalUpdates.get(key);
-        if (current !== pending) {
-            return;
-        }
-
-        const observedValue = this.getDevice(dr.id)?.getLocalCapabilityValue(dr.capabilityId)?.value;
-        if (observedValue === dr.value) {
-            this.pendingPhysicalUpdates.delete(key);
-            return;
-        }
-
-        if (pending.attempts < PHYSICAL_UPDATE_MAX_ATTEMPTS) {
-            this.calculator?.startCalculation(PHYSICAL_UPDATE_RETRY_BASE_DELAY * pending.attempts);
-            return;
-        }
-
-        this.pendingPhysicalUpdates.delete(key);
-        this.logger?.error(
-            `Physical update not confirmed after ${pending.attempts} attempts: ${dr.id}:${dr.capabilityId}`,
-            dr,
-        );
-    }
-
     private async updatePhysicalDevice(dr: DeviceRequest): Promise<void> {
+        const key = capabilityIdFormat(dr.id, dr.capabilityId);
         const pending = this.trackPhysicalUpdate(dr);
         try {
             const capability = this.getDevice(dr.id)?.getLocalCapabilityValue(dr.capabilityId);
@@ -485,9 +478,10 @@ export class Devices {
             }
             this.logger?.verbose(`Update device:(other): ${dr.id}:${dr.capabilityId} -> ${dr.value}`);
         } catch (err) {
+            if (this.pendingPhysicalUpdates.get(key) === pending) {
+                this.pendingPhysicalUpdates.delete(key);
+            }
             this.logger?.error('Update devices: UPDATE DEVICE failed:', dr, err);
-        } finally {
-            this.schedulePhysicalUpdateReconciliation(dr, pending);
         }
     }
 

--- a/tasks/github-issues/49-output-write-reconciliation.md
+++ b/tasks/github-issues/49-output-write-reconciliation.md
@@ -22,8 +22,8 @@ This overlaps the broader fail-safe work for GitHub #57, but this task specifica
 
 1. Await every physical capability write and preserve error handling and request ordering.
 2. Track desired and last-confirmed physical values separately, or roll back/re-read the cached value after a failed write.
-3. Add bounded, idempotent retry with backoff for safety-critical `onoff: false` writes.
-4. Reconcile actual capability state after timeout or rejection so an intended write cannot permanently suppress later attempts.
+3. Keep the latest desired value pending and allow an opposite command to supersede an earlier queued write.
+4. Reconcile actual capability state after confirmation or rejection so an intended write cannot permanently suppress later commands.
 5. Apply the same guarantees to master-to-child `target_temperature` writes.
 6. Ensure contact-alarm and inactive-state transitions use the reliable shutdown path.
 7. Log the controller decision, write attempt, confirmation, retry, and final failure distinctly.
@@ -38,15 +38,16 @@ This overlaps the broader fail-safe work for GitHub #57, but this task specifica
 
 ## Done when
 
-VThermo cannot report a successfully applied output state solely from an unconfirmed write, failed writes are retried or surfaced clearly, and the regression cases pass.
+VThermo cannot report a successfully applied output state solely from an unconfirmed write, failed writes remain eligible for a later calculation, and the regression cases pass.
 
 ## Resolution
 
 - Physical capability requests no longer overwrite the API-observed value before Homey reports the change through the capability subscription.
 - Delayed and undelayed writes now share one awaited, sequential error-handling path.
-- A rejected or unconfirmed write remains eligible for recalculation instead of being suppressed by an optimistic cached value.
-- Unconfirmed `onoff` and `target_temperature` writes receive at most three automatic attempts, with delays of 5 and 10 seconds before the second and third attempts.
-- A matching capability event clears the pending write; an update still unconfirmed after the third attempt is logged explicitly. Later independent calculations may begin a new bounded attempt sequence.
-- Regression tests cover pending undelayed writes, rejection and retry eligibility, bounded backoff, capability-event confirmation, and continuation after a failed device.
+- A rejected write is cleared so it remains eligible for a later calculation instead of being suppressed by an optimistic cached value.
+- An accepted but unconfirmed command is not resent merely because another calculation runs.
+- A new opposite command supersedes the pending value even when the device still reports the newly desired state. This preserves command order when Homey has queued the earlier write.
+- Matching capability events and refreshed snapshots clear pending writes. Obsolete events do not replace the latest desired command.
+- Regression tests cover pending undelayed writes, rapid command reversal, duplicate suppression, obsolete and matching confirmations, rejected writes, and continuation after a failed device.
 
 Homey capability confirmation is still software-level confirmation, not proof of physical relay state. Independent hardware temperature limits remain appropriate for safety-critical heating.

--- a/tasks/github-issues/57-fail-safe-heater-shutdown.md
+++ b/tasks/github-issues/57-fail-safe-heater-shutdown.md
@@ -31,8 +31,8 @@ The failure can be reproduced and automatically recovered or failed safe, with r
 - Missing target or temperature input deliberately retains the current heater output. Automatically forcing heaters off is not a safe universal default because a sensor outage could leave a home cold or cause frozen pipes.
 - Calculation exceptions are logged and receive bounded automatic recovery attempts after 5 seconds, 30 seconds, and 2 minutes. A later device event starts a fresh calculation sequence.
 - App shutdown remains non-intrusive and does not change heater outputs.
-- Physical capability writes continue to use the confirmation and bounded retry behavior delivered with GitHub #49, so an unconfirmed off command is not mistaken for physical state.
+- Physical capability writes continue to use the confirmation and latest-command reconciliation delivered with GitHub #49, so an unconfirmed off command is not mistaken for physical state and obsolete commands cannot override newer intent.
 - The related all-stale aggregation and awaited physical-write failures were already resolved in their expected-failure tasks and remain covered by the full suite.
-- Regression tests cover output retention for missing inputs, transient calculation recovery, bounded calculation retries, stale-value fallback, rejected writes, capability confirmation, and bounded output retries.
+- Regression tests cover output retention for missing inputs, transient calculation recovery, bounded calculation retries, stale-value fallback, rejected writes, capability confirmation, rapid reversals, and duplicate output suppression.
 
 There is no software-only default that eliminates both overheating and loss-of-heating risk. VThermo does not claim certified safety behavior; independent hardware minimum/maximum temperature protection remains appropriate for the installation.

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -326,7 +326,7 @@ describe('Devices updates to Homey', () => {
         expect(completedBeforeWrite).toBe(false);
     });
 
-    it('keeps a rejected physical update eligible for the next calculation', async () => {
+    it('clears a rejected physical update so the next calculation can try again', async () => {
         const heater = makeApiDevice({id: 'heater', deviceClass: DeviceClass.heater, capabilities: {onoff: true}});
         const startCalculation = vi.fn();
         const devices = new Devices({heater} as any, {
@@ -342,32 +342,68 @@ describe('Devices updates to Homey', () => {
 
         expect(physical.getLocalCapabilityValue('onoff').value).toBe(true);
         expect(retry).toMatchObject({id: 'heater', capabilityId: 'onoff', value: false});
-        expect(startCalculation).toHaveBeenCalledWith(5000);
+        expect(startCalculation).not.toHaveBeenCalled();
     });
 
-    it('bounds automatic retries while a physical update remains unconfirmed', async () => {
+    it('sends a reversal that supersedes an opposite unconfirmed physical update', async () => {
+        const heater = makeApiDevice({id: 'heater', deviceClass: DeviceClass.heater, capabilities: {onoff: false}});
+        const setCapabilityValue = vi.fn().mockResolvedValue(undefined);
+        const devices = new Devices({heater} as any, {app: {setCapabilityValue}});
+        const calculator = new DeviceCalculator(new Zones(), devices);
+        const physical = devices.getDevice('heater')!;
+
+        const turnOn = calculator.updateAndCreateDeviceRequestIfChanged(physical, 'onoff', true);
+        await devices.updateDevices(request(turnOn!));
+        const turnOff = calculator.updateAndCreateDeviceRequestIfChanged(physical, 'onoff', false);
+        await devices.updateDevices(request(turnOff!));
+
+        expect(setCapabilityValue.mock.calls).toEqual([
+            ['heater', 'onoff', true],
+            ['heater', 'onoff', false],
+        ]);
+    });
+
+    it('does not resend an identical physical update while it remains unconfirmed', async () => {
         const heater = makeApiDevice({id: 'heater', deviceClass: DeviceClass.heater, capabilities: {onoff: true}});
         const setCapabilityValue = vi.fn().mockResolvedValue(undefined);
-        const startCalculation = vi.fn();
-        const logger = {error: vi.fn(), verbose: vi.fn(), info: vi.fn()};
-        const devices = new Devices({heater} as any, {app: {setCapabilityValue}}, logger);
-        devices.setCalculator({startCalculation} as any);
-        const off = request({id: 'heater', capabilityId: 'onoff', value: false});
+        const devices = new Devices({heater} as any, {app: {setCapabilityValue}});
+        const calculator = new DeviceCalculator(new Zones(), devices);
+        const physical = devices.getDevice('heater')!;
 
-        await devices.updateDevices(off);
-        await devices.updateDevices(off);
-        await devices.updateDevices(off);
+        const turnOff = calculator.updateAndCreateDeviceRequestIfChanged(physical, 'onoff', false);
+        await devices.updateDevices(request(turnOff!));
+        const duplicate = calculator.updateAndCreateDeviceRequestIfChanged(physical, 'onoff', false);
 
-        expect(setCapabilityValue).toHaveBeenCalledTimes(3);
+        expect(setCapabilityValue).toHaveBeenCalledOnce();
         expect(devices.getDevice('heater')?.getLocalCapabilityValue('onoff').value).toBe(true);
-        expect(startCalculation.mock.calls).toEqual([[5000], [10000]]);
-        expect(logger.error).toHaveBeenCalledWith(
-            expect.stringContaining('not confirmed after 3 attempts'),
-            off.getRequests()[0],
-        );
+        expect(duplicate).toBeUndefined();
     });
 
-    it('stops retrying when a capability event confirms the physical update', async () => {
+    it('keeps the latest desired value pending when an obsolete confirmation arrives', async () => {
+        let capabilityListener!: (value: unknown) => void;
+        const heater = makeApiDevice({id: 'heater', deviceClass: DeviceClass.heater, capabilities: {onoff: false}});
+        heater.makeCapabilityInstance = vi.fn((_id: string, listener: (value: unknown) => void) => {
+            capabilityListener = listener;
+            return {destroy: vi.fn()};
+        });
+        const devices = new Devices({heater} as any, {
+            app: {setCapabilityValue: vi.fn().mockResolvedValue(undefined)},
+        });
+        const calculator = new DeviceCalculator(new Zones(), devices);
+        const physical = devices.getDevice('heater')!;
+
+        const turnOn = calculator.updateAndCreateDeviceRequestIfChanged(physical, 'onoff', true);
+        await devices.updateDevices(request(turnOn!));
+        const turnOff = calculator.updateAndCreateDeviceRequestIfChanged(physical, 'onoff', false);
+        await devices.updateDevices(request(turnOff!));
+
+        capabilityListener(true);
+        expect(calculator.updateAndCreateDeviceRequestIfChanged(physical, 'onoff', false)).toBeUndefined();
+        capabilityListener(false);
+        expect(physical.getLocalCapabilityValue('onoff').value).toBe(false);
+    });
+
+    it('clears a pending physical update when a capability event confirms it', async () => {
         let capabilityListener!: (value: unknown) => void;
         const heater = makeApiDevice({id: 'heater', deviceClass: DeviceClass.heater, capabilities: {onoff: true}});
         heater.makeCapabilityInstance = vi.fn((_id: string, listener: (value: unknown) => void) => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -155,5 +155,7 @@ export function makeDevicesStub(devices: Device[]): Devices {
             inZones(zones).some(device => device.getLocalCapabilityValue('alarm_contact')?.value === true),
         hasMotionAlarm: (zones: Zone | Zone[] | undefined) =>
             inZones(zones).some(device => device.getLocalCapabilityValue('alarm_motion')?.value === true),
+        isPhysicalUpdateRequired: (device: Device, capabilityId: string, value: unknown) =>
+            device.hasChangedValue(capabilityId, value),
     } as Devices;
 }


### PR DESCRIPTION
## Summary

- track the latest desired physical capability value separately from Homey's observed value
- send an opposite command even when the device still reports that state, so it supersedes an earlier queued command
- suppress duplicate unconfirmed writes and remove physical confirmation retries from the shared calculation timer
- keep rejected writes eligible for a later independent calculation and reconcile confirmations from events and refresh snapshots

This is a follow-up correction to #49 based on the rapid on/off behavior observed in Homey with queued Z-Wave wall-plug commands.

## Regression coverage

The tests reproduce false -> queued true -> desired false and verify that Homey receives both ordered commands. They also cover duplicate suppression, obsolete confirmations, matching confirmations, and rejected-write eligibility.

## Verification

- npm run build
- npm run lint
- npm test (145 tests)
- Homey publish-level app validation through the test postscript

## Hardware limitations

The behavior was reproduced from the supplied Homey log and covered with unit tests. It has not yet been verified on a real Homey or Z-Wave network.